### PR TITLE
readme: added archlinux aur package in install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 That's all !
 
+### Linux packages
+
+* [Archlinux (AUR)](https://aur.archlinux.org/packages/?K=git-bug)
+
 ## CLI usage
 
 Create a new bug:


### PR DESCRIPTION
some persons made archlinux packages for git-bug:
* one to compile from git
* one to compile from the latest stable version
* one to get the binary from the latest release

i added that to the readme.

let me know if i did something wrong.