### PR TITLE
Add open/close in bug view

### DIFF
--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -94,12 +94,12 @@ func (sb *showBug) layout(g *gocui.Gui) error {
 	}
 
 	v.Clear()
-	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation [o] Toggle open/close ")
+	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation ")
 
 	if sb.isOnSide {
 		fmt.Fprint(v, "[a] Add label [r] Remove label")
 	} else {
-		fmt.Fprint(v, "[c] Comment [t] Change title")
+		fmt.Fprint(v, "[o] Toggle open/close [c] Comment [t] Change title")
 	}
 
 	_, err = g.SetViewOnTop(showBugInstructionView)
@@ -610,10 +610,13 @@ func (sb *showBug) setTitle(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (sb *showBug) toggleOpenClose(g *gocui.Gui, v *gocui.View) error {
-	if sb.bug.Snapshot().Status.String() == "open" {
+	switch sb.bug.Snapshot().Status {
+	case bug.OpenStatus:
 		return sb.bug.Close()
-	} else {
-	return sb.bug.Open()		
+	case bug.ClosedStatus:
+		return sb.bug.Open()
+	default:
+		return nil
 	}
 }
 

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -94,7 +94,7 @@ func (sb *showBug) layout(g *gocui.Gui) error {
 	}
 
 	v.Clear()
-	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation ")
+	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation [o] Toggle open/close ")
 
 	if sb.isOnSide {
 		fmt.Fprint(v, "[a] Add label [r] Remove label")
@@ -168,6 +168,12 @@ func (sb *showBug) keybindings(g *gocui.Gui) error {
 	// Comment
 	if err := g.SetKeybinding(showBugView, 'c', gocui.ModNone,
 		sb.comment); err != nil {
+		return err
+	}
+
+	// Open/close
+	if err := g.SetKeybinding(showBugView, 'o', gocui.ModNone,
+		sb.toggleOpenClose); err != nil {
 		return err
 	}
 
@@ -601,6 +607,14 @@ func (sb *showBug) comment(g *gocui.Gui, v *gocui.View) error {
 
 func (sb *showBug) setTitle(g *gocui.Gui, v *gocui.View) error {
 	return setTitleWithEditor(sb.bug)
+}
+
+func (sb *showBug) toggleOpenClose(g *gocui.Gui, v *gocui.View) error {
+	if sb.bug.Snapshot().Status.String() == "open" {
+		return sb.bug.Close()
+	} else {
+	return sb.bug.Open()		
+	}
 }
 
 func (sb *showBug) addLabel(g *gocui.Gui, v *gocui.View) error {


### PR DESCRIPTION
Makes the key 'o' toggle a bug open or closed in the `termui` bug view. Feel free to bikeshed the specific key to activate this functionality (or even if a toggle behavior is appropriate).

I have very little experience with go, so if this isn't idiomatic, feel free to point it out.

Closes  #29.