### PR TITLE
Make comments editable in termui

### DIFF
--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -233,3 +233,7 @@ func (c *BugCache) CommitAsNeeded() error {
 	}
 	return nil
 }
+
+func (c *BugCache) Repo() *RepoCache {
+	return c.repoCache
+}

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -29,7 +29,7 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if commentAddMessage == "" {
-		commentAddMessage, err = input.BugCommentEditorInput(backend)
+		commentAddMessage, err = input.BugCommentEditorInput(backend, "")
 		if err == input.ErrEmptyMessage {
 			fmt.Println("Empty message, aborting.")
 			return nil

--- a/input/input.go
+++ b/input/input.go
@@ -113,6 +113,42 @@ func BugCommentEditorInput(repo repository.RepoCommon) (string, error) {
 	return message, nil
 }
 
+const bugEditCommentTemplate = `%s
+
+# Please enter the comment message. Lines starting with '#' will be ignored,
+# and an empty message aborts the operation.
+`
+
+// BugEditCommentEditorInput will open the default editor in the terminal with a
+// template for the user to fill. The file is then processed to extract a comment.
+func BugEditCommentEditorInput(repo repository.RepoCommon, preMessage string) (string, error) {
+	template := fmt.Sprintf(bugEditCommentTemplate, preMessage)
+	raw, err := launchEditorWithTemplate(repo, messageFilename, template)
+
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(raw, "\n")
+
+	var buffer bytes.Buffer
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		buffer.WriteString(line)
+		buffer.WriteString("\n")
+	}
+
+	message := strings.TrimSpace(buffer.String())
+
+	if message == "" {
+		return "", ErrEmptyMessage
+	}
+
+	return message, nil
+}
+
 const bugTitleTemplate = `%s
 
 # Please enter the new title. Only one line will used.

--- a/input/input.go
+++ b/input/input.go
@@ -78,7 +78,7 @@ func BugCreateEditorInput(repo repository.RepoCommon, preTitle string, preMessag
 	return title, message, nil
 }
 
-const bugCommentTemplate = `
+const bugCommentTemplate = `%s
 
 # Please enter the comment message. Lines starting with '#' will be ignored,
 # and an empty message aborts the operation.
@@ -86,43 +86,8 @@ const bugCommentTemplate = `
 
 // BugCommentEditorInput will open the default editor in the terminal with a
 // template for the user to fill. The file is then processed to extract a comment.
-func BugCommentEditorInput(repo repository.RepoCommon) (string, error) {
-	raw, err := launchEditorWithTemplate(repo, messageFilename, bugCommentTemplate)
-
-	if err != nil {
-		return "", err
-	}
-
-	lines := strings.Split(raw, "\n")
-
-	var buffer bytes.Buffer
-	for _, line := range lines {
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		buffer.WriteString(line)
-		buffer.WriteString("\n")
-	}
-
-	message := strings.TrimSpace(buffer.String())
-
-	if message == "" {
-		return "", ErrEmptyMessage
-	}
-
-	return message, nil
-}
-
-const bugEditCommentTemplate = `%s
-
-# Please enter the comment message. Lines starting with '#' will be ignored,
-# and an empty message aborts the operation.
-`
-
-// BugEditCommentEditorInput will open the default editor in the terminal with a
-// template for the user to fill. The file is then processed to extract a comment.
-func BugEditCommentEditorInput(repo repository.RepoCommon, preMessage string) (string, error) {
-	template := fmt.Sprintf(bugEditCommentTemplate, preMessage)
+func BugCommentEditorInput(repo repository.RepoCommon, preMessage string) (string, error) {
+	template := fmt.Sprintf(bugCommentTemplate, preMessage)
 	raw, err := launchEditorWithTemplate(repo, messageFilename, template)
 
 	if err != nil {

--- a/termui/select_popup.go
+++ b/termui/select_popup.go
@@ -1,0 +1,217 @@
+package termui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jroimartin/gocui"
+)
+
+const selectPopupView = "selectPopupView"
+const showSelectInstructions = "showSelectInstructions"
+
+type selectPopup struct {
+	active       bool
+	title        string
+	options      []string
+	optionSelect []bool
+	selected     int
+	childViews   []string
+	c            chan []string
+}
+
+func newSelectPopup() *selectPopup {
+	return &selectPopup{}
+}
+
+func (sp *selectPopup) keybindings(g *gocui.Gui) error {
+	// Close
+	if err := g.SetKeybinding(selectPopupView, gocui.KeyEsc, gocui.ModNone, sp.close); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding(selectPopupView, 'q', gocui.ModNone, sp.close); err != nil {
+		return err
+	}
+
+	// Validate
+	if err := g.SetKeybinding(selectPopupView, gocui.KeyEnter, gocui.ModNone, sp.validate); err != nil {
+		return err
+	}
+
+	// Up
+	if err := g.SetKeybinding(selectPopupView, gocui.KeyArrowUp, gocui.ModNone, sp.selectPrevious); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding(selectPopupView, 'k', gocui.ModNone, sp.selectPrevious); err != nil {
+		return err
+	}
+
+	// Down
+	if err := g.SetKeybinding(selectPopupView, gocui.KeyArrowDown, gocui.ModNone, sp.selectNext); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding(selectPopupView, 'j', gocui.ModNone, sp.selectNext); err != nil {
+		return err
+	}
+
+	// Select
+	if err := g.SetKeybinding(selectPopupView, gocui.KeySpace, gocui.ModNone, sp.selectItem); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding(selectPopupView, 'x', gocui.ModNone, sp.selectItem); err != nil {
+		return err
+	}
+
+	// Add
+	if err := g.SetKeybinding(selectPopupView, 'a', gocui.ModNone, sp.addItem); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sp *selectPopup) layout(g *gocui.Gui) error {
+	if !sp.active {
+		return nil
+	}
+
+	maxX, maxY := g.Size()
+
+	// TODO: Make width adaptive
+	width := 30
+	height := 2*len(sp.options) + 3
+	x0 := (maxX - width) / 2
+	y0 := (maxY - height) / 2
+
+	v, err := g.SetView(selectPopupView, x0, y0, x0+width, y0+height)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+
+		v.Frame = true
+		v.Title = sp.title
+	}
+
+	y0 += 1
+
+	for i, name := range sp.options {
+		viewname := fmt.Sprintf("view%d", i)
+		v, err = g.SetView(viewname, x0+2, y0, x0+width-2, y0+2)
+		sp.childViews = append(sp.childViews, viewname)
+		v.Frame = i == sp.selected
+		v.Clear()
+
+		selectBox := " [ ] "
+		if sp.optionSelect[i] {
+			selectBox = " [x] "
+		}
+
+		fmt.Fprint(v, selectBox + name)
+
+		y0 += 2
+	}
+
+	v, err = g.SetView(showSelectInstructions, x0, y0, x0+width, y0+2)
+	sp.childViews = append(sp.childViews, showSelectInstructions)
+	if err != nil {
+		if err != gocui.ErrUnknownView{
+			return err
+		}
+
+		v.Frame = false
+		v.BgColor = gocui.ColorBlue
+	}
+
+	v.Clear()
+	fmt.Fprint(v, "[↓↑,jk] Nav [a] Add item")
+
+	if _, err = g.SetViewOnTop(showSelectInstructions); err != nil {
+		return err
+	}
+
+	if _, err := g.SetCurrentView(selectPopupView); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func(sp *selectPopup) selectPrevious(g *gocui.Gui, v*gocui.View) error {
+	sp.selected = maxInt(0, sp.selected-1)
+
+	return nil
+}
+
+func(sp *selectPopup) selectNext(g *gocui.Gui, v*gocui.View) error {
+	sp.selected = minInt(len(sp.options)-1, sp.selected+1)
+
+	return nil
+}
+
+func(sp *selectPopup) selectItem(g *gocui.Gui, v*gocui.View) error {
+	sp.optionSelect[sp.selected] = !sp.optionSelect[sp.selected]
+
+	return nil
+}
+
+func (sp *selectPopup) addItem(g *gocui.Gui, v *gocui.View) error {
+	c := ui.inputPopup.Activate("Add item")
+
+	go func() {
+		input := <-c
+		input = strings.TrimSuffix(input, "\n")
+		input = strings.Replace(input, " ", "-", -1)
+
+		sp.options = append(sp.options, input)
+		sp.optionSelect = append(sp.optionSelect, true)
+	}()
+
+	return nil
+}
+
+func (sp *selectPopup) close(g *gocui.Gui, v *gocui.View) error {
+	sp.title = ""
+	sp.active = false
+
+	for _, v := range sp.childViews {
+		if err := g.DeleteView(v); err != nil && err != gocui.ErrUnknownView {
+			return err
+		}
+	}
+
+	return g.DeleteView(selectPopupView)
+}
+
+func (sp *selectPopup) validate(g *gocui.Gui, v *gocui.View) error {
+	sp.title = ""
+
+	if err := sp.close(g, v); err != nil {
+		return err
+	}
+
+	selectedOptions := []string{}
+	for i, option := range sp.options {
+		if sp.optionSelect[i] {
+			selectedOptions = append(selectedOptions, option)
+		}
+	}
+
+	sp.c <- selectedOptions
+
+	return nil
+}
+
+func (sp *selectPopup) Activate(title string, options []string, sel bool) <-chan []string {
+	sp.title = title
+	sp.options = options
+	sp.optionSelect = make([]bool, len(options))
+	for i, _ := range sp.optionSelect {
+		sp.optionSelect[i] = sel
+	}
+	sp.selected = 0
+	sp.active = true
+	sp.c = make(chan []string)
+
+	return sp.c
+}

--- a/termui/select_popup.go
+++ b/termui/select_popup.go
@@ -208,13 +208,10 @@ func (sp *selectPopup) validate(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
-func (sp *selectPopup) Activate(title string, options []string, sel bool) <-chan []string {
+func (sp *selectPopup) Activate(title string, options []string, sel []bool) <-chan []string {
 	sp.title = title
 	sp.options = options
-	sp.optionSelect = make([]bool, len(options))
-	for i, _ := range sp.optionSelect {
-		sp.optionSelect[i] = sel
-	}
+	sp.optionSelect = sel
 	sp.selected = 0
 	sp.active = true
 	sp.c = make(chan []string)

--- a/termui/select_popup.go
+++ b/termui/select_popup.go
@@ -29,14 +29,12 @@ func (sp *selectPopup) keybindings(g *gocui.Gui) error {
 	if err := g.SetKeybinding(selectPopupView, gocui.KeyEsc, gocui.ModNone, sp.close); err != nil {
 		return err
 	}
-	if err := g.SetKeybinding(selectPopupView, 'q', gocui.ModNone, sp.close); err != nil {
+
+	// Validate
+	if err := g.SetKeybinding(selectPopupView, 'q', gocui.ModNone, sp.validate); err != nil {
 		return err
 	}
 
-	// Validate
-	if err := g.SetKeybinding(selectPopupView, gocui.KeyEnter, gocui.ModNone, sp.validate); err != nil {
-		return err
-	}
 
 	// Up
 	if err := g.SetKeybinding(selectPopupView, gocui.KeyArrowUp, gocui.ModNone, sp.selectPrevious); err != nil {
@@ -59,6 +57,9 @@ func (sp *selectPopup) keybindings(g *gocui.Gui) error {
 		return err
 	}
 	if err := g.SetKeybinding(selectPopupView, 'x', gocui.ModNone, sp.selectItem); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding(selectPopupView, gocui.KeyEnter, gocui.ModNone, sp.selectItem); err != nil {
 		return err
 	}
 
@@ -124,7 +125,7 @@ func (sp *selectPopup) layout(g *gocui.Gui) error {
 	}
 
 	v.Clear()
-	fmt.Fprint(v, "[↓↑,jk] Nav [a] Add item")
+	fmt.Fprint(v, "[↓↑,jk] Nav [a] Add item [q] Save and close")
 
 	if _, err = g.SetViewOnTop(showSelectInstructions); err != nil {
 		return err
@@ -165,6 +166,8 @@ func (sp *selectPopup) addItem(g *gocui.Gui, v *gocui.View) error {
 
 		sp.options = append(sp.options, input)
 		sp.optionSelect = append(sp.optionSelect, true)
+
+		sp.selected = len(sp.options) - 1
 	}()
 
 	return nil

--- a/termui/select_popup.go
+++ b/termui/select_popup.go
@@ -98,7 +98,10 @@ func (sp *selectPopup) layout(g *gocui.Gui) error {
 
 	for i, name := range sp.options {
 		viewname := fmt.Sprintf("view%d", i)
-		v, err = g.SetView(viewname, x0+2, y0, x0+width-2, y0+2)
+		v, err := g.SetView(viewname, x0+2, y0, x0+width-2, y0+2)
+		if err != nil && err != gocui.ErrUnknownView {
+			return err
+		}
 		sp.childViews = append(sp.childViews, viewname)
 		v.Frame = i == sp.selected
 		v.Clear()

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -25,7 +25,6 @@ type showBug struct {
 	bug                *cache.BugCache
 	childViews         []string
 	mainSelectableView []string
-	mainTimelineIndex  []int
 	sideSelectableView []string
 	selected           string
 	isOnSide           bool
@@ -200,7 +199,6 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	snap := sb.bug.Snapshot()
 
 	sb.mainSelectableView = nil
-	sb.mainTimelineIndex = nil
 
 	createTimelineItem := snap.Timeline[0].(*bug.CreateTimelineItem)
 
@@ -219,7 +217,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	)
 	bugHeader, lines := text.Wrap(bugHeader, maxX)
 
-	v, err := sb.createOpView(g, showBugHeaderView, -1, x0, y0, maxX+1, lines, false)
+	v, err := sb.createOpView(g, showBugHeaderView, x0, y0, maxX+1, lines, false)
 	if err != nil {
 		return err
 	}
@@ -239,7 +237,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			create := op.(*bug.CreateTimelineItem)
 			content, lines := text.WrapLeftPadded(create.Message, maxX, 4)
 
-			v, err := sb.createOpView(g, viewName, i, x0, y0, maxX+1, lines, true)
+			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
 				return err
 			}
@@ -263,7 +261,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			)
 			content, lines = text.Wrap(content, maxX)
 
-			v, err := sb.createOpView(g, viewName, i, x0, y0, maxX+1, lines, true)
+			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
 				return err
 			}
@@ -280,7 +278,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			)
 			content, lines := text.Wrap(content, maxX)
 
-			v, err := sb.createOpView(g, viewName, i, x0, y0, maxX+1, lines, true)
+			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
 				return err
 			}
@@ -297,7 +295,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			)
 			content, lines := text.Wrap(content, maxX)
 
-			v, err := sb.createOpView(g, viewName, i, x0, y0, maxX+1, lines, true)
+			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
 				return err
 			}
@@ -346,7 +344,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			)
 			content, lines := text.Wrap(content, maxX)
 
-			v, err := sb.createOpView(g, viewName, i, x0, y0, maxX+1, lines, true)
+			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
 				return err
 			}
@@ -358,7 +356,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	return nil
 }
 
-func (sb *showBug) createOpView(g *gocui.Gui, name string, index int, x0 int, y0 int, maxX int, height int, selectable bool) (*gocui.View, error) {
+func (sb *showBug) createOpView(g *gocui.Gui, name string, x0 int, y0 int, maxX int, height int, selectable bool) (*gocui.View, error) {
 	v, err := g.SetView(name, x0, y0, maxX, y0+height+1)
 
 	if err != nil && err != gocui.ErrUnknownView {

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -95,13 +95,7 @@ func (sb *showBug) layout(g *gocui.Gui) error {
 	}
 
 	v.Clear()
-	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation ")
-
-	if sb.isOnSide {
-		fmt.Fprint(v, "[a] Add label [r] Remove label")
-	} else {
-		fmt.Fprint(v, "[c] Comment [t] Change title")
-	}
+	fmt.Fprintf(v, "[q] Save and return [←↓↑→,hjkl] Navigation [e] Edit selection [c] Comment [t] Change title")
 
 	_, err = g.SetViewOnTop(showBugInstructionView)
 	if err != nil {
@@ -652,7 +646,7 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 	if sb.isOnSide {
 		return sb.editLabels(g, v, snap)
 	}
-	
+
 	index := sb.getTimelineIndex()
 
 	if index == -1 {

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -18,10 +18,11 @@ type termUI struct {
 
 	activeWindow window
 
-	bugTable   *bugTable
-	showBug    *showBug
-	msgPopup   *msgPopup
-	inputPopup *inputPopup
+	bugTable    *bugTable
+	showBug     *showBug
+	msgPopup    *msgPopup
+	inputPopup  *inputPopup
+	selectPopup *selectPopup
 }
 
 func (tui *termUI) activateWindow(window window) error {
@@ -45,12 +46,13 @@ type window interface {
 // Run will launch the termUI in the terminal
 func Run(cache *cache.RepoCache) error {
 	ui = &termUI{
-		gError:     make(chan error, 1),
-		cache:      cache,
-		bugTable:   newBugTable(cache),
-		showBug:    newShowBug(cache),
-		msgPopup:   newMsgPopup(),
-		inputPopup: newInputPopup(),
+		gError:      make(chan error, 1),
+		cache:       cache,
+		bugTable:    newBugTable(cache),
+		showBug:     newShowBug(cache),
+		msgPopup:    newMsgPopup(),
+		inputPopup:  newInputPopup(),
+		selectPopup: newSelectPopup(),
 	}
 
 	ui.activeWindow = ui.bugTable
@@ -118,6 +120,10 @@ func layout(g *gocui.Gui) error {
 		return err
 	}
 
+	if err := ui.selectPopup.layout(g); err != nil {
+		return err
+	}
+
 	if err := ui.msgPopup.layout(g); err != nil {
 		return err
 	}
@@ -140,6 +146,10 @@ func keybindings(g *gocui.Gui) error {
 	}
 
 	if err := ui.showBug.keybindings(g); err != nil {
+		return err
+	}
+
+	if err := ui.selectPopup.keybindings(g); err != nil {
 		return err
 	}
 

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -211,7 +211,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	ui.g.Close()
 	ui.g = nil
 
-	message, err := input.BugCommentEditorInput(ui.cache)
+	message, err := input.BugCommentEditorInput(ui.cache, "")
 
 	if err != nil && err != input.ErrEmptyMessage {
 		return err
@@ -231,7 +231,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	return errTerminateMainloop
 }
 
-func editCommentWithEditor(bug *cache.BugCache, target git.Hash, message string) error {
+func editCommentWithEditor(bug *cache.BugCache, target git.Hash, preMessage string) error {
 	// This is somewhat hacky.
 	// As there is no way to pause gocui, run the editor and restart gocui,
 	// we have to stop it entirely and start a new one later.
@@ -244,16 +244,17 @@ func editCommentWithEditor(bug *cache.BugCache, target git.Hash, message string)
 	ui.g.Close()
 	ui.g = nil
 
-	message, err := input.BugEditCommentEditorInput(ui.cache, message)
+	message, err := input.BugCommentEditorInput(ui.cache, preMessage)
 
 	if err != nil && err != input.ErrEmptyMessage {
 		return err
 	}
 
 	if err == input.ErrEmptyMessage {
-		// This doesn't really make sense for editing a comment because
-		// an empty message is a valid comment.
+		// TODO: Allow comments to be deleted?
 		ui.msgPopup.Activate(msgPopupErrorTitle, "Empty message, aborting.")
+	} else if message == preMessage {
+		ui.msgPopup.Activate(msgPopupErrorTitle, "No changes found, aborting.")
 	} else {
 		err := bug.EditComment(target, message)
 		if err != nil {


### PR DESCRIPTION
This PR makes it possible to edit comments in `termui` mode with 'e'. As it stands now, only comments are editable, however it might make sense to put more functionality under edit. For example, editing labels and the title could also be triggered with 'e' when the appropriate view is selected.

Also, there seems to be a lot of code duplication in `termui`. Would you be welcome to a PR to reduce this duplication?