### PR TITLE
Allow setting a default remote

### DIFF
--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/text"
+	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/dustin/go-humanize"
 	"github.com/jroimartin/gocui"
 )
@@ -17,7 +18,6 @@ const bugTableHeaderView = "bugTableHeaderView"
 const bugTableFooterView = "bugTableFooterView"
 const bugTableInstructionView = "bugTableInstructionView"
 
-const defaultRemote = "origin"
 const defaultQuery = "status:open"
 
 type bugTable struct {
@@ -401,6 +401,15 @@ func (bt *bugTable) openBug(g *gocui.Gui, v *gocui.View) error {
 func (bt *bugTable) pull(g *gocui.Gui, v *gocui.View) error {
 	// Note: this is very hacky
 
+	defaultRemote, err := git.GetConfig("gitbug.defaultremote")
+	if err != nil {
+		if _, ok := err.(*git.ErrNotFound); ok {
+			ui.msgPopup.Activate(msgPopupErrorTitle, "No default remote configured")
+		} else {
+			return err
+		}
+	}
+
 	ui.msgPopup.Activate("Pull from remote "+defaultRemote, "...")
 
 	go func() {
@@ -458,6 +467,15 @@ func (bt *bugTable) pull(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (bt *bugTable) push(g *gocui.Gui, v *gocui.View) error {
+	defaultRemote, err := git.GetConfig("gitbug.defaultremote")
+	if err != nil {
+		if _, ok := err.(*git.ErrNotFound); ok {
+			ui.msgPopup.Activate(msgPopupErrorTitle, "No default remote configured")
+		} else {
+			return err
+		}
+	}
+
 	ui.msgPopup.Activate("Push to remote "+defaultRemote, "...")
 
 	go func() {

--- a/util/git/config.go
+++ b/util/git/config.go
@@ -1,0 +1,49 @@
+package git
+
+// Based off https://github.com/tcnksm/go-gitconfig which
+// has a MIT license
+
+import (
+	"os/exec"
+	"bytes"
+	"io/ioutil"
+	"syscall"
+	"strings"
+	"fmt"
+)
+
+type ErrNotFound struct {
+	Key string
+}
+
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("the key %s was not found", e.Key)
+}
+
+func GetConfig(key string) (string, error) {
+	cmd := exec.Command("git", "config", "--get", "--null", key)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = ioutil.Discard
+
+	err := cmd.Run()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
+			if waitStatus.ExitStatus() == 1 {
+				return "", &ErrNotFound{Key: key}
+			}
+		}
+
+		return "", err
+	}
+
+	return strings.TrimRight(stdout.String(), "\000"), nil
+}
+
+func SetConfig(key string, value string) error {
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	return cmd.Run()
+}


### PR DESCRIPTION
Adds some code to read and write gitconfig files, and uses it to enable default remotes.

This is based off code at [go-gitconfig](https://github.com/tcnksm/go-gitconfig). I would have just used that code, but the project seems abandoned, and it is licensed as MIT.

Closes #11.