### PR TITLE
[WIP] Cleaning lock files on Interruption

### DIFF
--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -21,7 +21,8 @@ func Register(f t) {
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 			<-ch
-			fmt.Println("")
+                        // Prevent un-terminated ^C character in terminal
+			fmt.Println()
 			clean()
 			os.Exit(1)
 		}()

--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -1,0 +1,38 @@
+package cleaner
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type t func() error
+
+var cleaners []t
+var inactive bool
+
+// Register a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
+func Register(f t) {
+	cleaners = append(cleaners, f)
+	if !inactive {
+		inactive = false
+		go func() {
+			ch := make(chan os.Signal, 1)
+			signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+			<-ch
+			fmt.Println("")
+			clean()
+			os.Exit(1)
+		}()
+	}
+}
+
+// Clean invokes all registered cleanup functions
+func clean() {
+	fmt.Println("Cleaning")
+	for _, f := range cleaners {
+		_ = f()
+	}
+	cleaners = []t{}
+}

--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 )
 
-type t func() error
+type Cleaner func() error
 
 var cleaners []t
 var inactive bool

--- a/cleaner/cleaner.go
+++ b/cleaner/cleaner.go
@@ -9,11 +9,11 @@ import (
 
 type Cleaner func() error
 
-var cleaners []t
+var cleaners []Cleaner
 var inactive bool
 
 // Register a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
-func Register(f t) {
+func Register(f Cleaner) {
 	cleaners = append(cleaners, f)
 	if !inactive {
 		inactive = false
@@ -21,7 +21,7 @@ func Register(f t) {
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 			<-ch
-                        // Prevent un-terminated ^C character in terminal
+			// Prevent un-terminated ^C character in terminal
 			fmt.Println()
 			clean()
 			os.Exit(1)
@@ -35,5 +35,5 @@ func clean() {
 	for _, f := range cleaners {
 		_ = f()
 	}
-	cleaners = []t{}
+	cleaners = []Cleaner{}
 }

--- a/commands/add.go
+++ b/commands/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/input"
 	"github.com/spf13/cobra"
 )
@@ -22,6 +23,7 @@ func runAddBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	if addMessageFile != "" && addMessage == "" {
 		addTitle, addMessage, err = input.BugCreateFileInput(addMessageFile)

--- a/commands/add.go
+++ b/commands/add.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/input"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ func runAddBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	if addMessageFile != "" && addMessage == "" {
 		addTitle, addMessage, err = input.BugCreateFileInput(addMessageFile)

--- a/commands/bridge.go
+++ b/commands/bridge.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runBridge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	configured, err := bridge.ConfiguredBridges(backend)
 	if err != nil {

--- a/commands/bridge.go
+++ b/commands/bridge.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,7 @@ func runBridge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	configured, err := bridge.ConfiguredBridges(backend)
 	if err != nil {

--- a/commands/bridge_configure.go
+++ b/commands/bridge_configure.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ func runBridgeConfigure(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	target, err := promptTarget()
 	if err != nil {

--- a/commands/bridge_configure.go
+++ b/commands/bridge_configure.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +19,7 @@ func runBridgeConfigure(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	target, err := promptTarget()
 	if err != nil {

--- a/commands/bridge_pull.go
+++ b/commands/bridge_pull.go
@@ -4,7 +4,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +14,7 @@ func runBridgePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	var b *core.Bridge
 

--- a/commands/bridge_pull.go
+++ b/commands/bridge_pull.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,7 @@ func runBridgePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	var b *core.Bridge
 

--- a/commands/bridge_rm.go
+++ b/commands/bridge_rm.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func runBridgeRm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	err = bridge.RemoveBridges(backend, args[0])
 	if err != nil {

--- a/commands/bridge_rm.go
+++ b/commands/bridge_rm.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/MichaelMure/git-bug/bridge"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,7 @@ func runBridgeRm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	err = bridge.RemoveBridges(backend, args[0])
 	if err != nil {

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/text"
@@ -17,6 +18,7 @@ func runComment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/MichaelMure/git-bug/util/text"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ func runComment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/input"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,7 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/input"
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/deselect.go
+++ b/commands/deselect.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ func runDeselect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	err = _select.Clear(backend)
 	if err != nil {

--- a/commands/deselect.go
+++ b/commands/deselect.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func runDeselect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	err = _select.Clear(backend)
 	if err != nil {

--- a/commands/label.go
+++ b/commands/label.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func runLabel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/label.go
+++ b/commands/label.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runLabel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/label_add.go
+++ b/commands/label_add.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runLabelAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/label_add.go
+++ b/commands/label_add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func runLabelAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/label_rm.go
+++ b/commands/label_rm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func runLabelRm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/label_rm.go
+++ b/commands/label_rm.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runLabelRm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/ls-labels.go
+++ b/commands/ls-labels.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,7 @@ func runLsLabel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	labels := backend.ValidLabels()
 

--- a/commands/ls-labels.go
+++ b/commands/ls-labels.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +14,7 @@ func runLsLabel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	labels := backend.ValidLabels()
 

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func runLsBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	var query *cache.Query
 	if len(args) >= 1 {

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +26,7 @@ func runLsBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	var query *cache.Query
 	if len(args) >= 1 {

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,7 @@ func runPull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	fmt.Println("Fetching remote ...")
 

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +25,7 @@ func runPull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	fmt.Println("Fetching remote ...")
 

--- a/commands/push.go
+++ b/commands/push.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	stdout, err := backend.Push(remote)
 	if err != nil {

--- a/commands/push.go
+++ b/commands/push.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +24,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	stdout, err := backend.Push(remote)
 	if err != nil {

--- a/commands/select.go
+++ b/commands/select.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ func runSelect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	prefix := args[0]
 

--- a/commands/select.go
+++ b/commands/select.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ func runSelect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	prefix := args[0]
 

--- a/commands/show.go
+++ b/commands/show.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +18,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/show.go
+++ b/commands/show.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status.go
+++ b/commands/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status.go
+++ b/commands/status.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status_close.go
+++ b/commands/status_close.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ func runStatusClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status_close.go
+++ b/commands/status_close.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func runStatusClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status_open.go
+++ b/commands/status_open.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func runStatusOpen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/status_open.go
+++ b/commands/status_open.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ func runStatusOpen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/termui.go
+++ b/commands/termui.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/termui"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ func runTermUI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	return termui.Run(backend)
 }

--- a/commands/termui.go
+++ b/commands/termui.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/termui"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func runTermUI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	return termui.Run(backend)
 }

--- a/commands/title.go
+++ b/commands/title.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func runTitle(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/title.go
+++ b/commands/title.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +15,7 @@ func runTitle(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/title_edit.go
+++ b/commands/title_edit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/input"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func runTitleEdit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	cleaner.Register(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/commands/title_edit.go
+++ b/commands/title_edit.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/cleaner"
 	"github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/input"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ func runTitleEdit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
-	cleaner.Register(backend.Close)
+	interrupt.RegisterCleaner(backend.Close)
 
 	b, args, err := _select.ResolveBug(backend, args)
 	if err != nil {

--- a/util/interrupt/cleaner.go
+++ b/util/interrupt/cleaner.go
@@ -1,4 +1,4 @@
-package cleaner
+package interrupt
 
 import (
 	"fmt"
@@ -12,8 +12,8 @@ type Cleaner func() error
 var cleaners []Cleaner
 var inactive bool
 
-// Register a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
-func Register(f Cleaner) {
+// RegisterCleaner is responsible for regisreting a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
+func RegisterCleaner(f Cleaner) {
 	cleaners = append(cleaners, f)
 	if !inactive {
 		inactive = false

--- a/util/interrupt/cleaner.go
+++ b/util/interrupt/cleaner.go
@@ -14,19 +14,21 @@ var cleaners []Cleaner
 var active = false
 
 // RegisterCleaner is responsible for regisreting a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
-func RegisterCleaner(f Cleaner) {
-	cleaners = append(cleaners, f)
-	if !active {
-		active = true
-		go func() {
-			ch := make(chan os.Signal, 1)
-			signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
-			<-ch
-			// Prevent un-terminated ^C character in terminal
-			fmt.Println()
-			clean()
-			os.Exit(1)
-		}()
+func RegisterCleaner(f ...Cleaner) {
+	for _, fn := range f {
+		cleaners = append(cleaners, fn)
+		if !active {
+			active = true
+			go func() {
+				ch := make(chan os.Signal, 1)
+				signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+				<-ch
+				// Prevent un-terminated ^C character in terminal
+				fmt.Println()
+				clean()
+				os.Exit(1)
+			}()
+		}
 	}
 }
 

--- a/util/interrupt/cleaner.go
+++ b/util/interrupt/cleaner.go
@@ -7,16 +7,17 @@ import (
 	"syscall"
 )
 
+// Cleaner type referes to a function with no inputs that returns an error
 type Cleaner func() error
 
 var cleaners []Cleaner
-var inactive bool
+var active = false
 
 // RegisterCleaner is responsible for regisreting a cleaner function. When a function is registered, the Signal watcher is started in a goroutine.
 func RegisterCleaner(f Cleaner) {
 	cleaners = append(cleaners, f)
-	if !inactive {
-		inactive = false
+	if !active {
+		active = true
 		go func() {
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)

--- a/util/interrupt/cleaner_test.go
+++ b/util/interrupt/cleaner_test.go
@@ -1,0 +1,33 @@
+package interrupt
+
+import (
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	active = true // this prevents goroutine from being started during the tests
+
+	f := func() error {
+		return nil
+	}
+	f2 := func() error {
+		return nil
+	}
+	f3 := func() error {
+		return nil
+	}
+	RegisterCleaner(f)
+	RegisterCleaner(f2, f3)
+	count := 0
+	for _, fn := range cleaners {
+		errt := fn()
+		count++
+		if errt != nil {
+			t.Fatalf("bad err value")
+		}
+	}
+	if count != 3 {
+		t.Fatalf("different number of errors")
+	}
+
+}


### PR DESCRIPTION
This PR attemps to solve issue #42 

### What was done: 
I created a "cleaner" package where all lockfile removal functions will be registered, and in can any interruption signal is recieved, the these functions will be executed first.

### How it was tested:
As far as I know, there is no way to create unit tests for this. ~~I created an [Issue](https://github.com/auyer/git-bug/issues/1) on my fork in case someone figures out how to test this.~~
As far as manual tests go, I repetedly performend manual interruptions on a long running `git bug ls` several times, and killed the text editor responsible by `git bug add`. 

Please, test it with your test cases, and report the results here.