### PR TITLE
tests: configure user ident in repos used by tests

### DIFF
--- a/bug/bug_actions_test.go
+++ b/bug/bug_actions_test.go
@@ -31,6 +31,13 @@ func createRepo(bare bool) *repository.GitRepo {
 		log.Fatal(err)
 	}
 
+	if err := repo.StoreConfig("user.name", "testuser"); err != nil {
+		log.Fatal("failed to set user.name for test repository: ", err)
+	}
+	if err := repo.StoreConfig("user.email", "testuser@example.com"); err != nil {
+		log.Fatal("failed to set user.email for test repository: ", err)
+	}
+
 	return repo
 }
 

--- a/commands/select/select_test.go
+++ b/commands/select/select_test.go
@@ -96,6 +96,13 @@ func createRepo() *repository.GitRepo {
 		log.Fatal(err)
 	}
 
+	if err := repo.StoreConfig("user.name", "testuser"); err != nil {
+		log.Fatal("failed to set user.name for test repository: ", err)
+	}
+	if err := repo.StoreConfig("user.email", "testuser@example.com"); err != nil {
+		log.Fatal("failed to set user.email for test repository: ", err)
+	}
+
 	return repo
 }
 

--- a/tests/read_bugs_test.go
+++ b/tests/read_bugs_test.go
@@ -31,6 +31,13 @@ func createRepo(bare bool) *repository.GitRepo {
 		log.Fatal(err)
 	}
 
+	if err := repo.StoreConfig("user.name", "testuser"); err != nil {
+		log.Fatal("failed to set user.name for test repository: ", err)
+	}
+	if err := repo.StoreConfig("user.email", "testuser@example.com"); err != nil {
+		log.Fatal("failed to set user.email for test repository: ", err)
+	}
+
 	return repo
 }
 


### PR DESCRIPTION
Some git operations require the user to have an identity configured and
will exit with failure if none is set (or if git can't guess it). As a
direct consequence of this, the test suite may fail depending on the
user local configuration.

The error itself is justified as regular users *should* configure their
identity themselves. However, when building in chrooted environments
it's unlikely the git identity will be set making the test suite fail
unnecessarily.

To prevent such unnecessary failures, let's make a dummy identity for
repos created and used by the test suite.