### PR TITLE
Allow empty messages in comments.

### DIFF
--- a/bug/op_add_comment.go
+++ b/bug/op_add_comment.go
@@ -58,10 +58,6 @@ func (op *AddCommentOperation) Validate() error {
 		return err
 	}
 
-	if text.Empty(op.Message) {
-		return fmt.Errorf("message is empty")
-	}
-
 	if !text.Safe(op.Message) {
 		return fmt.Errorf("message is not fully printable")
 	}

--- a/bug/operation_test.go
+++ b/bug/operation_test.go
@@ -47,7 +47,6 @@ func TestValidate(t *testing.T) {
 		NewSetTitleOp(rene, unix, "title", "multi\nline"),
 		NewSetTitleOp(rene, unix, "title\u001b", "title2"),
 		NewSetTitleOp(rene, unix, "title", "title2\u001b"),
-		NewAddCommentOp(rene, unix, "", nil),
 		NewAddCommentOp(rene, unix, "message\u001b", nil),
 		NewAddCommentOp(rene, unix, "message", []git.Hash{git.Hash("invalid")}),
 		NewSetStatusOp(rene, unix, 1000),

--- a/commands/show.go
+++ b/commands/show.go
@@ -58,6 +58,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 	indent := "  "
 
 	for i, comment := range snapshot.Comments {
+		var message string
 		fmt.Printf("%s#%d %s <%s>\n\n",
 			indent,
 			i,
@@ -65,9 +66,15 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 			comment.Author.Email,
 		)
 
+		if comment.Message == "" {
+			message = colors.GreyBold("No description provided.")
+		} else {
+			message = comment.Message
+		}
+
 		fmt.Printf("%s%s\n\n\n",
 			indent,
-			comment.Message,
+			message,
 		)
 	}
 


### PR DESCRIPTION
Some bug trackers, like Launchpad, allow messages to be empty (when adding a
file to the bug, for instance).