### PR TITLE
show command - id switch and use example in hook script/

### DIFF
--- a/commands/show.go
+++ b/commands/show.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	showId	bool
+)
 func runShowBug(cmd *cobra.Command, args []string) error {
 	backend, err := cache.NewRepoCache(repo)
 	if err != nil {
@@ -27,6 +30,10 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 
 	snapshot := b.Snapshot()
 
+	if showId {
+		fmt.Printf("%s\n",snapshot.HumanId())
+		return nil
+	}
 	if len(snapshot.Comments) == 0 {
 		return errors.New("Invalid bug: no comment")
 	}
@@ -90,4 +97,5 @@ var showCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(showCmd)
+	showCmd.Flags().BoolVarP(&showId,"id","i",false,"Select field to display: id")
 }

--- a/contrib/hooks/prepare-commit-msg
+++ b/contrib/hooks/prepare-commit-msg
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Insert selected git-bug issue identifier in the comment.
+# if no selected issue, print in comments the list of open issues.
+#
+cmtChar=`git config --get core.commentchar`
+hashChar="#"
+if [ "$cmtChar" = "" ]
+then
+	cmtChar="#"
+fi
+if [ "$cmtChar" = "#" ]
+then
+	hashChar=":"
+fi
+
+case "$2,$3" in
+#  merge,)
+#    /usr/bin/perl -i.bak -ne 's/^/# /, s/^# #/#/ if /^Conflicts/ .. /#/; print' "$1" ;;
+#
+# ,|template,)
+#   /usr/bin/perl -i.bak -pe '
+#      print "\n" . `git diff --cached --name-status -r`
+#	 if /^#/ && $first++ == ' "$1" ;;
+
+  *) 
+        ISSUE=`git bug show --id`
+	if [ "$ISSUE" = "" ]
+	then
+		echo "$cmtChar !!!!! insert $hashChar<issue_id> in your comment, pick one in list below." >> "$1"
+		git bug ls status:open |sed 's/ open\t/ /'| sed "s/^/$cmtChar/" >> "$1"
+	else
+		sed -i "1i$hashChar$ISSUE " "$1"
+	fi
+	;;
+esac


### PR DESCRIPTION
Added --id switch to the show command to only get the selected bug id. This is introduced to ease the implementation of a hook script to pre-fill the commit message with the current bug id as hashtag. Getting only the id prevent to use acrobatic pipes of sed that may suffer change in the regular text ouptut format.
The prepare-commit-msg git hook script I use with this hack for my own projects is provided in the new contrib directory included in this pull request.
