### PR TITLE
Issue #87: use same id format function in snapshot.go than in bug.go

### DIFF
--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -30,7 +30,7 @@ func (snap *Snapshot) Id() string {
 
 // Return the Bug identifier truncated for human consumption
 func (snap *Snapshot) HumanId() string {
-	return fmt.Sprintf("%.8s", snap.id)
+	return FormatHumanID(snap.id)
 }
 
 // Deprecated:should be moved in UI code


### PR DESCRIPTION
After some fight with my git, here is the best fix I can actually do for the short id format issue. May be some there are aother alternate HumanID() implementation somewhere. I didn't find any by doing basic search with grep.