### PR TITLE
ls-id.go: Fixing ls-id

### DIFF
--- a/commands/ls-id.go
+++ b/commands/ls-id.go
@@ -16,8 +16,7 @@ func runLsID(cmd *cobra.Command, args []string) error {
 	}
 	defer backend.Close()
 
-	var prefix string
-	prefix = ""
+	var prefix = ""
 	if len(args) != 0 {
 		prefix = args[0]
 	}

--- a/commands/ls-id.go
+++ b/commands/ls-id.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,7 @@ func runLsID(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer backend.Close()
+	interrupt.RegisterCleaner(backend.Close)
 
 	var prefix = ""
 	if len(args) != 0 {

--- a/commands/ls-id.go
+++ b/commands/ls-id.go
@@ -10,9 +10,17 @@ import (
 
 func runLsID(cmd *cobra.Command, args []string) error {
 
-	var backend *cache.RepoCache
+	backend, err := cache.NewRepoCache(repo)
+	if err != nil {
+		return err
+	}
+	defer backend.Close()
 
-	prefix := args[0]
+	var prefix string
+	prefix = ""
+	if len(args) != 0 {
+		prefix = args[0]
+	}
 
 	for _, id := range backend.AllBugsIds() {
 		if prefix == "" || strings.HasPrefix(id, prefix) {


### PR DESCRIPTION
Adding check for length of args
Pulling bugIds from correct backend.