### PR TITLE
Select and Label command documentation

### DIFF
--- a/commands/comment.go
+++ b/commands/comment.go
@@ -46,7 +46,7 @@ func commentsTextOutput(comments []bug.Comment) {
 
 var commentCmd = &cobra.Command{
 	Use:     "comment [<id>]",
-	Short:   "Display or add comments.",
+	Short:   "Display or add comments to a bug.",
 	PreRunE: loadRepo,
 	RunE:    runComment,
 }

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -56,7 +56,7 @@ func runCommentAdd(cmd *cobra.Command, args []string) error {
 
 var commentAddCmd = &cobra.Command{
 	Use:     "add [<id>]",
-	Short:   "Add a new comment.",
+	Short:   "Add a new comment to a bug.",
 	PreRunE: loadRepo,
 	RunE:    runCommentAdd,
 }

--- a/commands/label.go
+++ b/commands/label.go
@@ -33,7 +33,7 @@ func runLabel(cmd *cobra.Command, args []string) error {
 
 var labelCmd = &cobra.Command{
 	Use:     "label [<id>]",
-	Short:   "Display, add or remove labels.",
+	Short:   "Display, add or remove labels to/from a bug.",
 	PreRunE: loadRepo,
 	RunE:    runLabel,
 }

--- a/commands/label_add.go
+++ b/commands/label_add.go
@@ -37,7 +37,7 @@ func runLabelAdd(cmd *cobra.Command, args []string) error {
 
 var labelAddCmd = &cobra.Command{
 	Use:     "add [<id>] <label>[...]",
-	Short:   "Add a label.",
+	Short:   "Add a label to a bug.",
 	PreRunE: loadRepo,
 	RunE:    runLabelAdd,
 }

--- a/commands/label_rm.go
+++ b/commands/label_rm.go
@@ -37,7 +37,7 @@ func runLabelRm(cmd *cobra.Command, args []string) error {
 
 var labelRmCmd = &cobra.Command{
 	Use:     "rm [<id>] <label>[...]",
-	Short:   "Remove a label.",
+	Short:   "Remove a label from a bug.",
 	PreRunE: loadRepo,
 	RunE:    runLabelRm,
 }

--- a/commands/select.go
+++ b/commands/select.go
@@ -48,12 +48,10 @@ git bug status
 `,
 	Long: `Select a bug for implicit use in future commands.
 
-This command allows you to omit any bug <id> argument for the following commands:
-  - git bug comment
-  - git bug label
-  - git bug show
-  - git bug status
-  - git bug title
+This command allows you to omit any bug <id> argument, for example:
+  git bug show
+instead of
+  git bug show 2f153ca
 
 The complementary command is "git bug deselect" performing the opposite operation.
 `,

--- a/commands/select.go
+++ b/commands/select.go
@@ -46,6 +46,17 @@ var selectCmd = &cobra.Command{
 git bug comment
 git bug status
 `,
+	Long: `Select a bug for implicit use in future commands.
+
+This command allows you to omit any bug <id> argument for the following commands:
+  - git bug comment
+  - git bug label
+  - git bug show
+  - git bug status
+  - git bug title
+
+The complementary command is "git bug deselect" performing the opposite operation.
+`,
 	PreRunE: loadRepo,
 	RunE:    runSelect,
 }

--- a/commands/select/select.go
+++ b/commands/select/select.go
@@ -16,7 +16,7 @@ import (
 
 const selectFile = "select"
 
-var ErrNoValidId = errors.New("you must provide a bug id")
+var ErrNoValidId = errors.New("you must provide a bug id or use the \"select\" command first")
 
 // ResolveBug first try to resolve a bug using the first argument of the command
 // line. If it fails, it fallback to the select mechanism.

--- a/commands/title.go
+++ b/commands/title.go
@@ -31,7 +31,7 @@ func runTitle(cmd *cobra.Command, args []string) error {
 
 var titleCmd = &cobra.Command{
 	Use:     "title [<id>]",
-	Short:   "Display or change a title.",
+	Short:   "Display or change a title of a bug.",
 	PreRunE: loadRepo,
 	RunE:    runTitle,
 }

--- a/commands/title_edit.go
+++ b/commands/title_edit.go
@@ -54,7 +54,7 @@ func runTitleEdit(cmd *cobra.Command, args []string) error {
 
 var titleEditCmd = &cobra.Command{
 	Use:     "edit [<id>]",
-	Short:   "Edit a title.",
+	Short:   "Edit a title of a bug.",
 	PreRunE: loadRepo,
 	RunE:    runTitleEdit,
 }

--- a/commands/user.go
+++ b/commands/user.go
@@ -49,7 +49,7 @@ func runUser(cmd *cobra.Command, args []string) error {
 }
 
 var userCmd = &cobra.Command{
-	Use:     "user [<id>]",
+	Use:     "user [<user-id>]",
 	Short:   "Display or change the user identity.",
 	PreRunE: loadRepo,
 	RunE:    runUser,

--- a/commands/user_adopt.go
+++ b/commands/user_adopt.go
@@ -35,7 +35,7 @@ func runUserAdopt(cmd *cobra.Command, args []string) error {
 }
 
 var userAdoptCmd = &cobra.Command{
-	Use:     "adopt <id>",
+	Use:     "adopt <user-id>",
 	Short:   "Adopt an existing identity as your own.",
 	PreRunE: loadRepo,
 	RunE:    runUserAdopt,


### PR DESCRIPTION
Hey @MichaelMure ! Ça roule?

I was getting started with the tool and got a bit confused when I tried to add a label. I thought it was creating a list of labels... So I thought I would give a bit more clues on these commands by adding a bit more info.

- Informed that label command adds/removes a label to a given bug.
- Added suggestion to use select command when omitting to provide a bug id as argument.
- Added a bit more detail for the select command documentation, giving a hint to "deselect" command.