### PR TITLE
cache/filter.go: Fix query match for --label 

### DIFF
--- a/cache/filter.go
+++ b/cache/filter.go
@@ -91,7 +91,7 @@ func (f *Filters) Match(repoCache *RepoCache, excerpt *BugExcerpt) bool {
 		return false
 	}
 
-	if match := f.orMatch(f.Label, repoCache, excerpt); !match {
+	if match := f.andMatch(f.Label, repoCache, excerpt); !match {
 		return false
 	}
 


### PR DESCRIPTION
Fixed filter query for multiple labels from
`OR` to `AND` according to github conventions.

Fixed https://github.com/MichaelMure/git-bug/issues/115