### PR TITLE
commands: ls fix CJK characters out of alignment

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -7,6 +7,7 @@ import (
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
+	"github.com/MichaelMure/git-bug/util/text"
 	"github.com/spf13/cobra"
 )
 
@@ -65,8 +66,8 @@ func runLsBug(cmd *cobra.Command, args []string) error {
 		}
 
 		// truncate + pad if needed
-		titleFmt := fmt.Sprintf("%-50.50s", b.Title)
-		authorFmt := fmt.Sprintf("%-15.15s", name)
+		titleFmt := text.LeftPadMaxLine(b.Title, 50, 0)
+		authorFmt := text.LeftPadMaxLine(name, 15, 0)
 
 		fmt.Printf("%s %s\t%s\t%s\tC:%d L:%d\n",
 			colors.Cyan(b.HumanId()),


### PR DESCRIPTION
#85

![image](https://user-images.githubusercontent.com/9934258/57708701-613eeb80-769c-11e9-9bec-2677027ad36d.png)
