### PR TITLE
Bridge: pull/push enhancements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -384,6 +384,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:b521f10a2d8fa85c04a8ef4e62f2d1e14d303599a55d64dabf9f5a02f84d35eb"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  pruneopts = "UT"
+  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
+
+[[projects]]
+  branch = "master"
   digest = "1:3364d01296ce7eeca363e3d530ae63a2092d6f8efb85fb3d101e8f6d7de83452"
   name = "golang.org/x/sys"
   packages = [
@@ -481,6 +489,7 @@
     "github.com/xanzy/go-gitlab",
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/oauth2",
+    "golang.org/x/sync/errgroup",
     "golang.org/x/text/runes",
     "golang.org/x/text/transform",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,3 +75,7 @@
 [[constraint]]
   name = "github.com/xanzy/go-gitlab"
   version = "0.20.0"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/sync"

--- a/bridge/core/bridge.go
+++ b/bridge/core/bridge.go
@@ -2,6 +2,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -289,26 +290,26 @@ func (b *Bridge) ensureInit() error {
 	return nil
 }
 
-func (b *Bridge) ImportAll(since time.Time) error {
+func (b *Bridge) ImportAll(ctx context.Context, since time.Time) (<-chan ImportResult, error) {
 	importer := b.getImporter()
 	if importer == nil {
-		return ErrImportNotSupported
+		return nil, ErrImportNotSupported
 	}
 
 	err := b.ensureConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = b.ensureInit()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return importer.ImportAll(b.repo, since)
+	return importer.ImportAll(ctx, b.repo, since)
 }
 
-func (b *Bridge) ExportAll(since time.Time) (<-chan ExportResult, error) {
+func (b *Bridge) ExportAll(ctx context.Context, since time.Time) (<-chan ExportResult, error) {
 	exporter := b.getExporter()
 	if exporter == nil {
 		return nil, ErrExportNotSupported
@@ -324,5 +325,5 @@ func (b *Bridge) ExportAll(since time.Time) (<-chan ExportResult, error) {
 		return nil, err
 	}
 
-	return exporter.ExportAll(b.repo, since)
+	return exporter.ExportAll(ctx, b.repo, since)
 }

--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -17,6 +17,7 @@ const (
 	ExportEventTitleEdition
 	ExportEventLabelChange
 	ExportEventNothing
+	ExportEventError
 )
 
 // ExportResult is an event that is emitted during the export process, to
@@ -32,19 +33,28 @@ type ExportResult struct {
 func (er ExportResult) String() string {
 	switch er.Event {
 	case ExportEventBug:
-		return "new issue"
+		return fmt.Sprintf("new issue: %s", er.ID)
 	case ExportEventComment:
-		return "new comment"
+		return fmt.Sprintf("new comment: %s", er.ID)
 	case ExportEventCommentEdition:
-		return "updated comment"
+		return fmt.Sprintf("updated comment: %s", er.ID)
 	case ExportEventStatusChange:
-		return "changed status"
+		return fmt.Sprintf("changed status: %s", er.ID)
 	case ExportEventTitleEdition:
-		return "changed title"
+		return fmt.Sprintf("changed title: %s", er.ID)
 	case ExportEventLabelChange:
-		return "changed label"
+		return fmt.Sprintf("changed label: %s", er.ID)
 	case ExportEventNothing:
-		return fmt.Sprintf("no event: %v", er.Reason)
+		if er.ID != "" {
+			return fmt.Sprintf("ignoring export event %s: %s", er.ID, er.Reason)
+		}
+		return fmt.Sprintf("ignoring export event: %s", er.Reason)
+	case ExportEventError:
+		if er.ID != "" {
+			return fmt.Sprintf("export error at %s: %s", er.ID, er.Err.Error())
+		}
+		return fmt.Sprintf("export error: %s", er.Err.Error())
+
 	default:
 		panic("unknown export result")
 	}

--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -46,9 +46,9 @@ func (er ExportResult) String() string {
 		return fmt.Sprintf("changed label: %s", er.ID)
 	case ExportEventNothing:
 		if er.ID != "" {
-			return fmt.Sprintf("ignoring export event %s: %s", er.ID, er.Reason)
+			return fmt.Sprintf("no actions taken for event %s: %s", er.ID, er.Reason)
 		}
-		return fmt.Sprintf("ignoring export event: %s", er.Reason)
+		return fmt.Sprintf("no actions taken: %s", er.Reason)
 	case ExportEventError:
 		if er.ID != "" {
 			return fmt.Sprintf("export error at %s: %s", er.ID, er.Err.Error())

--- a/bridge/core/import.go
+++ b/bridge/core/import.go
@@ -49,9 +49,9 @@ func (er ImportResult) String() string {
 		return fmt.Sprintf("new identity: %s", er.ID)
 	case ImportEventNothing:
 		if er.ID != "" {
-			return fmt.Sprintf("ignoring import event %s: %s", er.ID, er.Reason)
+			return fmt.Sprintf("no action taken for event %s: %s", er.ID, er.Reason)
 		}
-		return fmt.Sprintf("ignoring event: %s", er.Reason)
+		return fmt.Sprintf("no action taken: %s", er.Reason)
 	case ImportEventError:
 		if er.ID != "" {
 			return fmt.Sprintf("import error at id %s: %s", er.ID, er.Err.Error())

--- a/bridge/core/import.go
+++ b/bridge/core/import.go
@@ -1,0 +1,128 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/MichaelMure/git-bug/entity"
+)
+
+type ImportEvent int
+
+const (
+	_ ImportEvent = iota
+	ImportEventBug
+	ImportEventComment
+	ImportEventCommentEdition
+	ImportEventStatusChange
+	ImportEventTitleEdition
+	ImportEventLabelChange
+	ImportEventIdentity
+	ImportEventNothing
+	ImportEventError
+)
+
+// ImportResult is an event that is emitted during the import process, to
+// allow calling code to report on what is happening, collect metrics or
+// display meaningful errors if something went wrong.
+type ImportResult struct {
+	Err    error
+	Event  ImportEvent
+	ID     entity.Id
+	Reason string
+}
+
+func (er ImportResult) String() string {
+	switch er.Event {
+	case ImportEventBug:
+		return fmt.Sprintf("new issue: %s", er.ID)
+	case ImportEventComment:
+		return fmt.Sprintf("new comment: %s", er.ID)
+	case ImportEventCommentEdition:
+		return fmt.Sprintf("updated comment: %s", er.ID)
+	case ImportEventStatusChange:
+		return fmt.Sprintf("changed status: %s", er.ID)
+	case ImportEventTitleEdition:
+		return fmt.Sprintf("changed title: %s", er.ID)
+	case ImportEventLabelChange:
+		return fmt.Sprintf("changed label: %s", er.ID)
+	case ImportEventIdentity:
+		return fmt.Sprintf("new identity: %s", er.ID)
+	case ImportEventNothing:
+		if er.ID != "" {
+			return fmt.Sprintf("ignoring import event %s: %s", er.ID, er.Reason)
+		}
+		return fmt.Sprintf("ignoring event: %s", er.Reason)
+	case ImportEventError:
+		if er.ID != "" {
+			return fmt.Sprintf("import error at id %s: %s", er.ID, er.Err.Error())
+		}
+		return fmt.Sprintf("import error: %s", er.Err.Error())
+	default:
+		panic("unknown import result")
+	}
+}
+
+func NewImportError(err error, id entity.Id) ImportResult {
+	return ImportResult{
+		Err:   err,
+		ID:    id,
+		Event: ImportEventError,
+	}
+}
+
+func NewImportNothing(id entity.Id, reason string) ImportResult {
+	return ImportResult{
+		ID:     id,
+		Reason: reason,
+		Event:  ImportEventNothing,
+	}
+}
+
+func NewImportBug(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventBug,
+	}
+}
+
+func NewImportComment(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventComment,
+	}
+}
+
+func NewImportCommentEdition(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventCommentEdition,
+	}
+}
+
+func NewImportStatusChange(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventStatusChange,
+	}
+}
+
+func NewImportLabelChange(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventLabelChange,
+	}
+}
+
+func NewImportTitleEdition(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventTitleEdition,
+	}
+}
+
+func NewImportIdentity(id entity.Id) ImportResult {
+	return ImportResult{
+		ID:    id,
+		Event: ImportEventIdentity,
+	}
+}

--- a/bridge/core/interfaces.go
+++ b/bridge/core/interfaces.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	"github.com/MichaelMure/git-bug/cache"
@@ -29,10 +30,10 @@ type BridgeImpl interface {
 
 type Importer interface {
 	Init(conf Configuration) error
-	ImportAll(repo *cache.RepoCache, since time.Time) error
+	ImportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan ImportResult, error)
 }
 
 type Exporter interface {
 	Init(conf Configuration) error
-	ExportAll(repo *cache.RepoCache, since time.Time) (<-chan ExportResult, error)
+	ExportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan ExportResult, error)
 }

--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -177,13 +178,14 @@ func TestPushPull(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	ctx := context.Background()
 	start := time.Now()
 
 	// export all bugs
-	events, err := exporter.ExportAll(backend, time.Time{})
+	exportEvents, err := exporter.ExportAll(ctx, backend, time.Time{})
 	require.NoError(t, err)
 
-	for result := range events {
+	for result := range exportEvents {
 		require.NoError(t, result.Err)
 	}
 	require.NoError(t, err)
@@ -206,8 +208,12 @@ func TestPushPull(t *testing.T) {
 	require.NoError(t, err)
 
 	// import all exported bugs to the second backend
-	err = importer.ImportAll(backendTwo, time.Time{})
+	importEvents, err := importer.ImportAll(ctx, backendTwo, time.Time{})
 	require.NoError(t, err)
+
+	for result := range importEvents {
+		require.NoError(t, result.Err)
+	}
 
 	require.Len(t, backendTwo.AllBugsIds(), len(tests))
 

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -369,8 +369,7 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 
 	targetOpID, err := b.ResolveOperationWithMetadata(keyGithubId, parseId(item.Id))
 	if err == nil {
-		reason := fmt.Sprintf("comment already imported")
-		gi.out <- core.NewImportNothing("", reason)
+		gi.out <- core.NewImportNothing("", "comment already imported")
 	} else if err != cache.ErrNoMatchingOp {
 		// real error
 		return err

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -28,11 +28,8 @@ type githubImporter struct {
 	// iterator
 	iterator *iterator
 
-	// number of imported issues
-	importedIssues int
-
-	// number of imported identities
-	importedIdentities int
+	// send only channel
+	out chan<- core.ImportResult
 }
 
 func (gi *githubImporter) Init(conf core.Configuration) error {
@@ -42,40 +39,49 @@ func (gi *githubImporter) Init(conf core.Configuration) error {
 
 // ImportAll iterate over all the configured repository issues and ensure the creation of the
 // missing issues / timeline items / edits / label events ...
-func (gi *githubImporter) ImportAll(repo *cache.RepoCache, since time.Time) error {
-	gi.iterator = NewIterator(gi.conf[keyOwner], gi.conf[keyProject], gi.conf[keyToken], since)
+func (gi *githubImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan core.ImportResult, error) {
+	gi.iterator = NewIterator(ctx, 10, gi.conf[keyOwner], gi.conf[keyProject], gi.conf[keyToken], since)
+	out := make(chan core.ImportResult)
+	gi.out = out
 
-	// Loop over all matching issues
-	for gi.iterator.NextIssue() {
-		issue := gi.iterator.IssueValue()
-		fmt.Printf("importing issue: %v\n", issue.Title)
+	go func() {
+		defer close(gi.out)
 
-		// create issue
-		b, err := gi.ensureIssue(repo, issue)
-		if err != nil {
-			return fmt.Errorf("issue creation: %v", err)
-		}
+		// Loop over all matching issues
+		for gi.iterator.NextIssue() {
+			issue := gi.iterator.IssueValue()
+			// create issue
+			b, err := gi.ensureIssue(repo, issue)
+			if err != nil {
+				err := fmt.Errorf("issue creation: %v", err)
+				out <- core.NewImportError(err, "")
+				return
+			}
 
-		// loop over timeline items
-		for gi.iterator.NextTimelineItem() {
-			if err := gi.ensureTimelineItem(repo, b, gi.iterator.TimelineItemValue()); err != nil {
-				return fmt.Errorf("timeline item creation: %v", err)
+			// loop over timeline items
+			for gi.iterator.NextTimelineItem() {
+				item := gi.iterator.TimelineItemValue()
+				if err := gi.ensureTimelineItem(repo, b, item); err != nil {
+					err := fmt.Errorf("timeline item creation: %v", err)
+					out <- core.NewImportError(err, "")
+					return
+				}
+			}
+
+			// commit bug state
+			if err := b.CommitAsNeeded(); err != nil {
+				err = fmt.Errorf("bug commit: %v", err)
+				out <- core.NewImportError(err, "")
+				return
 			}
 		}
 
-		// commit bug state
-		if err := b.CommitAsNeeded(); err != nil {
-			return fmt.Errorf("bug commit: %v", err)
+		if err := gi.iterator.Error(); err != nil && err != context.Canceled {
+			gi.out <- core.NewImportError(err, "")
 		}
-	}
+	}()
 
-	if err := gi.iterator.Error(); err != nil {
-		fmt.Printf("import error: %v\n", err)
-		return err
-	}
-
-	fmt.Printf("Successfully imported %d issues and %d identities from Github\n", gi.importedIssues, gi.importedIdentities)
-	return nil
+	return out, nil
 }
 
 func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline) (*cache.BugCache, error) {
@@ -122,7 +128,9 @@ func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline
 			}
 
 			// importing a new bug
-			gi.importedIssues++
+			gi.out <- core.NewImportBug(b.Id())
+		} else {
+			gi.out <- core.NewImportNothing("", "bug already imported")
 		}
 
 	} else {
@@ -130,6 +138,7 @@ func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline
 		for i, edit := range issueEdits {
 			if i == 0 && b != nil {
 				// The first edit in the github result is the issue creation itself, we already have that
+				gi.out <- core.NewImportNothing("", "bug already imported")
 				continue
 			}
 
@@ -159,13 +168,12 @@ func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline
 				}
 
 				// importing a new bug
-				gi.importedIssues++
-
+				gi.out <- core.NewImportBug(b.Id())
 				continue
 			}
 
 			// other edits will be added as CommentEdit operations
-			target, err := b.ResolveOperationWithMetadata(keyGithubUrl, issue.Url.String())
+			target, err := b.ResolveOperationWithMetadata(keyGithubId, parseId(issue.Id))
 			if err != nil {
 				return nil, err
 			}
@@ -181,16 +189,16 @@ func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline
 }
 
 func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.BugCache, item timelineItem) error {
-	fmt.Printf("import event item: %s\n", item.Typename)
 
 	switch item.Typename {
 	case "IssueComment":
 		// collect all comment edits
-		commentEdits := []userContentEdit{}
+		var commentEdits []userContentEdit
 		for gi.iterator.NextCommentEdit() {
 			commentEdits = append(commentEdits, gi.iterator.CommentEditValue())
 		}
 
+		// ensureTimelineComment send import events over out chanel
 		err := gi.ensureTimelineComment(repo, b, item.IssueComment, commentEdits)
 		if err != nil {
 			return fmt.Errorf("timeline comment creation: %v", err)
@@ -199,6 +207,12 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 	case "LabeledEvent":
 		id := parseId(item.LabeledEvent.Id)
 		_, err := b.ResolveOperationWithMetadata(keyGithubId, id)
+		if err == nil {
+			reason := fmt.Sprintf("operation already imported: %v", item.Typename)
+			gi.out <- core.NewImportNothing("", reason)
+			return nil
+		}
+
 		if err != cache.ErrNoMatchingOp {
 			return err
 		}
@@ -206,7 +220,7 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 		if err != nil {
 			return err
 		}
-		_, err = b.ForceChangeLabelsRaw(
+		op, err := b.ForceChangeLabelsRaw(
 			author,
 			item.LabeledEvent.CreatedAt.Unix(),
 			[]string{
@@ -215,12 +229,21 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 			nil,
 			map[string]string{keyGithubId: id},
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		gi.out <- core.NewImportLabelChange(op.Id())
+		return nil
 
 	case "UnlabeledEvent":
 		id := parseId(item.UnlabeledEvent.Id)
 		_, err := b.ResolveOperationWithMetadata(keyGithubId, id)
+		if err == nil {
+			reason := fmt.Sprintf("operation already imported: %v", item.Typename)
+			gi.out <- core.NewImportNothing("", reason)
+			return nil
+		}
 		if err != cache.ErrNoMatchingOp {
 			return err
 		}
@@ -229,7 +252,7 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 			return err
 		}
 
-		_, err = b.ForceChangeLabelsRaw(
+		op, err := b.ForceChangeLabelsRaw(
 			author,
 			item.UnlabeledEvent.CreatedAt.Unix(),
 			nil,
@@ -238,7 +261,12 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 			},
 			map[string]string{keyGithubId: id},
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportLabelChange(op.Id())
+		return nil
 
 	case "ClosedEvent":
 		id := parseId(item.ClosedEvent.Id)
@@ -246,16 +274,27 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 		if err != cache.ErrNoMatchingOp {
 			return err
 		}
+		if err == nil {
+			reason := fmt.Sprintf("operation already imported: %v", item.Typename)
+			gi.out <- core.NewImportNothing("", reason)
+			return nil
+		}
 		author, err := gi.ensurePerson(repo, item.ClosedEvent.Actor)
 		if err != nil {
 			return err
 		}
-		_, err = b.CloseRaw(
+		op, err := b.CloseRaw(
 			author,
 			item.ClosedEvent.CreatedAt.Unix(),
 			map[string]string{keyGithubId: id},
 		)
-		return err
+
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportStatusChange(op.Id())
+		return nil
 
 	case "ReopenedEvent":
 		id := parseId(item.ReopenedEvent.Id)
@@ -263,16 +302,27 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 		if err != cache.ErrNoMatchingOp {
 			return err
 		}
+		if err == nil {
+			reason := fmt.Sprintf("operation already imported: %v", item.Typename)
+			gi.out <- core.NewImportNothing("", reason)
+			return nil
+		}
 		author, err := gi.ensurePerson(repo, item.ReopenedEvent.Actor)
 		if err != nil {
 			return err
 		}
-		_, err = b.OpenRaw(
+		op, err := b.OpenRaw(
 			author,
 			item.ReopenedEvent.CreatedAt.Unix(),
 			map[string]string{keyGithubId: id},
 		)
-		return err
+
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportStatusChange(op.Id())
+		return nil
 
 	case "RenamedTitleEvent":
 		id := parseId(item.RenamedTitleEvent.Id)
@@ -280,20 +330,31 @@ func (gi *githubImporter) ensureTimelineItem(repo *cache.RepoCache, b *cache.Bug
 		if err != cache.ErrNoMatchingOp {
 			return err
 		}
+		if err == nil {
+			reason := fmt.Sprintf("operation already imported: %v", item.Typename)
+			gi.out <- core.NewImportNothing("", reason)
+			return nil
+		}
 		author, err := gi.ensurePerson(repo, item.RenamedTitleEvent.Actor)
 		if err != nil {
 			return err
 		}
-		_, err = b.SetTitleRaw(
+		op, err := b.SetTitleRaw(
 			author,
 			item.RenamedTitleEvent.CreatedAt.Unix(),
 			string(item.RenamedTitleEvent.CurrentTitle),
 			map[string]string{keyGithubId: id},
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportTitleEdition(op.Id())
+		return nil
 
 	default:
-		fmt.Printf("ignore event: %v\n", item.Typename)
+		reason := fmt.Sprintf("ignoring timeline type: %v", item.Typename)
+		gi.out <- core.NewImportNothing("", reason)
 	}
 
 	return nil
@@ -307,14 +368,16 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 	}
 
 	targetOpID, err := b.ResolveOperationWithMetadata(keyGithubId, parseId(item.Id))
-	if err != nil && err != cache.ErrNoMatchingOp {
+	if err == nil {
+		reason := fmt.Sprintf("comment already imported")
+		gi.out <- core.NewImportNothing("", reason)
+	} else if err != cache.ErrNoMatchingOp {
 		// real error
 		return err
 	}
 
 	// if no edits are given we create the comment
 	if len(edits) == 0 {
-		// if comment doesn't exist
 		if err == cache.ErrNoMatchingOp {
 			cleanText, err := text.Cleanup(string(item.Body))
 			if err != nil {
@@ -322,7 +385,7 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 			}
 
 			// add comment operation
-			_, err = b.AddCommentRaw(
+			op, err := b.AddCommentRaw(
 				author,
 				item.CreatedAt.Unix(),
 				cleanText,
@@ -332,12 +395,18 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 					keyGithubUrl: parseId(item.Url.String()),
 				},
 			)
-			return err
+			if err != nil {
+				return err
+			}
+
+			gi.out <- core.NewImportComment(op.Id())
 		}
+
 	} else {
 		for i, edit := range edits {
 			if i == 0 && targetOpID != "" {
 				// The first edit in the github result is the comment creation itself, we already have that
+				gi.out <- core.NewImportNothing("", "comment already imported")
 				continue
 			}
 
@@ -370,7 +439,6 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 
 				// set target for the nexr edit now that the comment is created
 				targetOpID = op.Id()
-
 				continue
 			}
 
@@ -386,15 +454,13 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugCache, target entity.Id, edit userContentEdit) error {
 	_, err := b.ResolveOperationWithMetadata(keyGithubId, parseId(edit.Id))
 	if err == nil {
-		// already imported
+		gi.out <- core.NewImportNothing(b.Id(), "edition already imported")
 		return nil
 	}
 	if err != cache.ErrNoMatchingOp {
 		// real error
 		return err
 	}
-
-	fmt.Println("import edition")
 
 	editor, err := gi.ensurePerson(repo, edit.Editor)
 	if err != nil {
@@ -404,7 +470,7 @@ func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugC
 	switch {
 	case edit.DeletedAt != nil:
 		// comment deletion, not supported yet
-		fmt.Println("comment deletion is not supported yet")
+		gi.out <- core.NewImportNothing(b.Id(), "comment deletion is not supported yet")
 
 	case edit.DeletedAt == nil:
 
@@ -414,7 +480,7 @@ func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugC
 		}
 
 		// comment edition
-		_, err = b.EditCommentRaw(
+		op, err := b.EditCommentRaw(
 			editor,
 			edit.CreatedAt.Unix(),
 			target,
@@ -427,6 +493,8 @@ func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugC
 		if err != nil {
 			return err
 		}
+
+		gi.out <- core.NewImportCommentEdition(op.Id())
 	}
 
 	return nil
@@ -450,7 +518,6 @@ func (gi *githubImporter) ensurePerson(repo *cache.RepoCache, actor *actor) (*ca
 	}
 
 	// importing a new identity
-	gi.importedIdentities++
 
 	var name string
 	var email string
@@ -471,7 +538,7 @@ func (gi *githubImporter) ensurePerson(repo *cache.RepoCache, actor *actor) (*ca
 	case "Bot":
 	}
 
-	return repo.NewIdentityRaw(
+	i, err = repo.NewIdentityRaw(
 		name,
 		email,
 		string(actor.Login),
@@ -480,6 +547,13 @@ func (gi *githubImporter) ensurePerson(repo *cache.RepoCache, actor *actor) (*ca
 			keyGithubLogin: string(actor.Login),
 		},
 	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	gi.out <- core.NewImportIdentity(i.Id())
+	return i, nil
 }
 
 func (gi *githubImporter) getGhost(repo *cache.RepoCache) (*cache.IdentityCache, error) {
@@ -500,8 +574,7 @@ func (gi *githubImporter) getGhost(repo *cache.RepoCache) (*cache.IdentityCache,
 
 	gc := buildClient(gi.conf[keyToken])
 
-	parentCtx := context.Background()
-	ctx, cancel := context.WithTimeout(parentCtx, defaultTimeout)
+	ctx, cancel := context.WithTimeout(gi.iterator.ctx, defaultTimeout)
 	defer cancel()
 
 	err = gc.Query(ctx, &q, variables)

--- a/bridge/github/import_test.go
+++ b/bridge/github/import_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -146,10 +147,15 @@ func Test_Importer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	ctx := context.Background()
 	start := time.Now()
 
-	err = importer.ImportAll(backend, time.Time{})
+	events, err := importer.ImportAll(ctx, backend, time.Time{})
 	require.NoError(t, err)
+
+	for result := range events {
+		require.NoError(t, result.Err)
+	}
 
 	fmt.Printf("test repository imported in %f seconds\n", time.Since(start).Seconds())
 

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -21,11 +22,8 @@ type gitlabImporter struct {
 	// iterator
 	iterator *iterator
 
-	// number of imported issues
-	importedIssues int
-
-	// number of imported identities
-	importedIdentities int
+	// send only channel
+	out chan<- core.ImportResult
 }
 
 func (gi *gitlabImporter) Init(conf core.Configuration) error {
@@ -35,49 +33,60 @@ func (gi *gitlabImporter) Init(conf core.Configuration) error {
 
 // ImportAll iterate over all the configured repository issues (notes) and ensure the creation
 // of the missing issues / comments / label events / title changes ...
-func (gi *gitlabImporter) ImportAll(repo *cache.RepoCache, since time.Time) error {
-	gi.iterator = NewIterator(gi.conf[keyProjectID], gi.conf[keyToken], since)
+func (gi *gitlabImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan core.ImportResult, error) {
+	gi.iterator = NewIterator(ctx, 10, gi.conf[keyProjectID], gi.conf[keyToken], since)
+	out := make(chan core.ImportResult)
+	gi.out = out
 
-	// Loop over all matching issues
-	for gi.iterator.NextIssue() {
-		issue := gi.iterator.IssueValue()
-		fmt.Printf("importing issue: %v\n", issue.Title)
+	go func() {
+		defer close(gi.out)
 
-		// create issue
-		b, err := gi.ensureIssue(repo, issue)
-		if err != nil {
-			return fmt.Errorf("issue creation: %v", err)
-		}
+		// Loop over all matching issues
+		for gi.iterator.NextIssue() {
+			issue := gi.iterator.IssueValue()
 
-		// Loop over all notes
-		for gi.iterator.NextNote() {
-			note := gi.iterator.NoteValue()
-			if err := gi.ensureNote(repo, b, note); err != nil {
-				return fmt.Errorf("note creation: %v", err)
+			// create issue
+			b, err := gi.ensureIssue(repo, issue)
+			if err != nil {
+				err := fmt.Errorf("issue creation: %v", err)
+				out <- core.NewImportError(err, "")
+				return
 			}
-		}
 
-		// Loop over all label events
-		for gi.iterator.NextLabelEvent() {
-			labelEvent := gi.iterator.LabelEventValue()
-			if err := gi.ensureLabelEvent(repo, b, labelEvent); err != nil {
-				return fmt.Errorf("label event creation: %v", err)
+			// Loop over all notes
+			for gi.iterator.NextNote() {
+				note := gi.iterator.NoteValue()
+				if err := gi.ensureNote(repo, b, note); err != nil {
+					err := fmt.Errorf("note creation: %v", err)
+					out <- core.NewImportError(err, entity.Id(strconv.Itoa(note.ID)))
+					return
+				}
+			}
+
+			// Loop over all label events
+			for gi.iterator.NextLabelEvent() {
+				labelEvent := gi.iterator.LabelEventValue()
+				if err := gi.ensureLabelEvent(repo, b, labelEvent); err != nil {
+					err := fmt.Errorf("label event creation: %v", err)
+					out <- core.NewImportError(err, entity.Id(strconv.Itoa(labelEvent.ID)))
+					return
+				}
+			}
+
+			// commit bug state
+			if err := b.CommitAsNeeded(); err != nil {
+				err := fmt.Errorf("bug commit: %v", err)
+				out <- core.NewImportError(err, "")
+				return
 			}
 		}
 
 		if err := gi.iterator.Error(); err != nil {
-			fmt.Printf("import error: %v\n", err)
-			return err
+			out <- core.NewImportError(err, "")
 		}
+	}()
 
-		// commit bug state
-		if err := b.CommitAsNeeded(); err != nil {
-			return fmt.Errorf("bug commit: %v", err)
-		}
-	}
-
-	fmt.Printf("Successfully imported %d issues and %d identities from Gitlab\n", gi.importedIssues, gi.importedIdentities)
-	return nil
+	return out, nil
 }
 
 func (gi *gitlabImporter) ensureIssue(repo *cache.RepoCache, issue *gitlab.Issue) (*cache.BugCache, error) {
@@ -89,12 +98,13 @@ func (gi *gitlabImporter) ensureIssue(repo *cache.RepoCache, issue *gitlab.Issue
 
 	// resolve bug
 	b, err := repo.ResolveBugCreateMetadata(keyGitlabUrl, issue.WebURL)
-	if err != nil && err != bug.ErrBugNotExist {
-		return nil, err
-	}
-
 	if err == nil {
+		reason := fmt.Sprintf("bug already imported")
+		gi.out <- core.NewImportNothing("", reason)
 		return b, nil
+	}
+	if err != bug.ErrBugNotExist {
+		return nil, err
 	}
 
 	// if bug was never imported
@@ -123,7 +133,7 @@ func (gi *gitlabImporter) ensureIssue(repo *cache.RepoCache, issue *gitlab.Issue
 	}
 
 	// importing a new bug
-	gi.importedIssues++
+	gi.out <- core.NewImportBug(b.Id())
 
 	return b, nil
 }
@@ -149,28 +159,36 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			return nil
 		}
 
-		_, err = b.CloseRaw(
+		op, err := b.CloseRaw(
 			author,
 			note.CreatedAt.Unix(),
 			map[string]string{
 				keyGitlabId: gitlabID,
 			},
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportStatusChange(op.Id())
 
 	case NOTE_REOPENED:
 		if errResolve == nil {
 			return nil
 		}
 
-		_, err = b.OpenRaw(
+		op, err := b.OpenRaw(
 			author,
 			note.CreatedAt.Unix(),
 			map[string]string{
 				keyGitlabId: gitlabID,
 			},
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		gi.out <- core.NewImportStatusChange(op.Id())
 
 	case NOTE_DESCRIPTION_CHANGED:
 		issue := gi.iterator.IssueValue()
@@ -181,7 +199,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// TODO: Check only one time and ignore next 'description change' within one issue
 		if errResolve == cache.ErrNoMatchingOp && issue.Description != firstComment.Message {
 			// comment edition
-			_, err = b.EditCommentRaw(
+			op, err := b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
 				firstComment.Id(),
@@ -190,8 +208,11 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 					keyGitlabId: gitlabID,
 				},
 			)
+			if err != nil {
+				return err
+			}
 
-			return err
+			gi.out <- core.NewImportTitleEdition(op.Id())
 		}
 
 	case NOTE_COMMENT:
@@ -204,7 +225,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		if errResolve == cache.ErrNoMatchingOp {
 
 			// add comment operation
-			_, err = b.AddCommentRaw(
+			op, err := b.AddCommentRaw(
 				author,
 				note.CreatedAt.Unix(),
 				cleanText,
@@ -213,8 +234,11 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 					keyGitlabId: gitlabID,
 				},
 			)
-
-			return err
+			if err != nil {
+				return err
+			}
+			gi.out <- core.NewImportComment(op.Id())
+			return nil
 		}
 
 		// if comment was already exported
@@ -228,7 +252,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// compare local bug comment with the new note body
 		if comment.Message != cleanText {
 			// comment edition
-			_, err = b.EditCommentRaw(
+			op, err := b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
 				comment.Id(),
@@ -236,7 +260,10 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 				nil,
 			)
 
-			return err
+			if err != nil {
+				return err
+			}
+			gi.out <- core.NewImportCommentEdition(op.Id())
 		}
 
 		return nil
@@ -247,7 +274,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			return nil
 		}
 
-		_, err = b.SetTitleRaw(
+		op, err := b.SetTitleRaw(
 			author,
 			note.CreatedAt.Unix(),
 			body,
@@ -255,8 +282,11 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 				keyGitlabId: gitlabID,
 			},
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		gi.out <- core.NewImportTitleEdition(op.Id())
 
 	case NOTE_UNKNOWN,
 		NOTE_ASSIGNED,
@@ -269,6 +299,9 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		NOTE_UNLOCKED,
 		NOTE_MENTIONED_IN_ISSUE,
 		NOTE_MENTIONED_IN_MERGE_REQUEST:
+
+		reason := fmt.Sprintf("unsupported note type: %s", noteType.String())
+		gi.out <- core.NewImportNothing("", reason)
 		return nil
 
 	default:
@@ -337,10 +370,7 @@ func (gi *gitlabImporter) ensurePerson(repo *cache.RepoCache, id int) (*cache.Id
 		return nil, err
 	}
 
-	// importing a new identity
-	gi.importedIdentities++
-
-	return repo.NewIdentityRaw(
+	i, err = repo.NewIdentityRaw(
 		user.Name,
 		user.PublicEmail,
 		user.Username,
@@ -351,6 +381,12 @@ func (gi *gitlabImporter) ensurePerson(repo *cache.RepoCache, id int) (*cache.Id
 			keyGitlabLogin: user.Username,
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	gi.out <- core.NewImportIdentity(i.Id())
+	return i, nil
 }
 
 func parseID(id int) string {

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -99,8 +99,7 @@ func (gi *gitlabImporter) ensureIssue(repo *cache.RepoCache, issue *gitlab.Issue
 	// resolve bug
 	b, err := repo.ResolveBugCreateMetadata(keyGitlabUrl, issue.WebURL)
 	if err == nil {
-		reason := fmt.Sprintf("bug already imported")
-		gi.out <- core.NewImportNothing("", reason)
+		gi.out <- core.NewImportNothing("", "bug already imported")
 		return b, nil
 	}
 	if err != bug.ErrBugNotExist {

--- a/bridge/gitlab/import_notes.go
+++ b/bridge/gitlab/import_notes.go
@@ -28,6 +28,45 @@ const (
 	NOTE_UNKNOWN
 )
 
+func (nt NoteType) String() string {
+	switch nt {
+	case NOTE_COMMENT:
+		return "note comment"
+	case NOTE_TITLE_CHANGED:
+		return "note title changed"
+	case NOTE_DESCRIPTION_CHANGED:
+		return "note description changed"
+	case NOTE_CLOSED:
+		return "note closed"
+	case NOTE_REOPENED:
+		return "note reopened"
+	case NOTE_LOCKED:
+		return "note locked"
+	case NOTE_UNLOCKED:
+		return "note unlocked"
+	case NOTE_CHANGED_DUEDATE:
+		return "note changed duedate"
+	case NOTE_REMOVED_DUEDATE:
+		return "note remove duedate"
+	case NOTE_ASSIGNED:
+		return "note assigned"
+	case NOTE_UNASSIGNED:
+		return "note unassigned"
+	case NOTE_CHANGED_MILESTONE:
+		return "note changed milestone"
+	case NOTE_REMOVED_MILESTONE:
+		return "note removed in milestone"
+	case NOTE_MENTIONED_IN_ISSUE:
+		return "note mentioned in issue"
+	case NOTE_MENTIONED_IN_MERGE_REQUEST:
+		return "note mentioned in merge request"
+	case NOTE_UNKNOWN:
+		return "note unknown"
+	default:
+		panic("unknown note type")
+	}
+}
+
 // GetNoteType parse a note system and body and return the note type and it content
 func GetNoteType(n *gitlab.Note) (NoteType, string) {
 	// when a note is a comment system is set to false

--- a/bridge/gitlab/import_test.go
+++ b/bridge/gitlab/import_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -99,9 +100,15 @@ func TestImport(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	ctx := context.Background()
 	start := time.Now()
-	err = importer.ImportAll(backend, time.Time{})
+
+	events, err := importer.ImportAll(ctx, backend, time.Time{})
 	require.NoError(t, err)
+
+	for result := range events {
+		require.NoError(t, result.Err)
+	}
 
 	fmt.Printf("test repository imported in %f seconds\n", time.Since(start).Seconds())
 

--- a/bridge/gitlab/iterator.go
+++ b/bridge/gitlab/iterator.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"time"
 
 	"github.com/xanzy/go-gitlab"
@@ -38,6 +39,9 @@ type iterator struct {
 	// number of issues and notes to query at once
 	capacity int
 
+	// shared context
+	ctx context.Context
+
 	// sticky error
 	err error
 
@@ -52,12 +56,13 @@ type iterator struct {
 }
 
 // NewIterator create a new iterator
-func NewIterator(projectID, token string, since time.Time) *iterator {
+func NewIterator(ctx context.Context, capacity int, projectID, token string, since time.Time) *iterator {
 	return &iterator{
 		gc:       buildClient(token),
 		project:  projectID,
 		since:    since,
-		capacity: 20,
+		capacity: capacity,
+		ctx:      ctx,
 		issue: &issueIterator{
 			index: -1,
 			page:  1,
@@ -79,6 +84,9 @@ func (i *iterator) Error() error {
 }
 
 func (i *iterator) getNextIssues() bool {
+	ctx, cancel := context.WithTimeout(i.ctx, defaultTimeout)
+	defer cancel()
+
 	issues, _, err := i.gc.Issues.ListProjectIssues(
 		i.project,
 		&gitlab.ListProjectIssuesOptions{
@@ -90,6 +98,7 @@ func (i *iterator) getNextIssues() bool {
 			UpdatedAfter: &i.since,
 			Sort:         gitlab.String("asc"),
 		},
+		gitlab.WithContext(ctx),
 	)
 
 	if err != nil {
@@ -116,6 +125,10 @@ func (i *iterator) NextIssue() bool {
 		return false
 	}
 
+	if i.ctx.Err() != nil {
+		return false
+	}
+
 	// first query
 	if i.issue.cache == nil {
 		return i.getNextIssues()
@@ -135,6 +148,9 @@ func (i *iterator) IssueValue() *gitlab.Issue {
 }
 
 func (i *iterator) getNextNotes() bool {
+	ctx, cancel := context.WithTimeout(i.ctx, defaultTimeout)
+	defer cancel()
+
 	notes, _, err := i.gc.Notes.ListIssueNotes(
 		i.project,
 		i.IssueValue().IID,
@@ -146,6 +162,7 @@ func (i *iterator) getNextNotes() bool {
 			Sort:    gitlab.String("asc"),
 			OrderBy: gitlab.String("created_at"),
 		},
+		gitlab.WithContext(ctx),
 	)
 
 	if err != nil {
@@ -171,6 +188,10 @@ func (i *iterator) NextNote() bool {
 		return false
 	}
 
+	if i.ctx.Err() != nil {
+		return false
+	}
+
 	if len(i.note.cache) == 0 {
 		return i.getNextNotes()
 	}
@@ -189,6 +210,9 @@ func (i *iterator) NoteValue() *gitlab.Note {
 }
 
 func (i *iterator) getNextLabelEvents() bool {
+	ctx, cancel := context.WithTimeout(i.ctx, defaultTimeout)
+	defer cancel()
+
 	labelEvents, _, err := i.gc.ResourceLabelEvents.ListIssueLabelEvents(
 		i.project,
 		i.IssueValue().IID,
@@ -198,6 +222,7 @@ func (i *iterator) getNextLabelEvents() bool {
 				PerPage: i.capacity,
 			},
 		},
+		gitlab.WithContext(ctx),
 	)
 
 	if err != nil {
@@ -221,6 +246,10 @@ func (i *iterator) getNextLabelEvents() bool {
 // because Gitlab
 func (i *iterator) NextLabelEvent() bool {
 	if i.err != nil {
+		return false
+	}
+
+	if i.ctx.Err() != nil {
 		return false
 	}
 

--- a/bridge/launchpad/import.go
+++ b/bridge/launchpad/import.go
@@ -1,10 +1,9 @@
 package launchpad
 
 import (
+	"context"
 	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bug"
@@ -45,98 +44,116 @@ func (li *launchpadImporter) ensurePerson(repo *cache.RepoCache, owner LPPerson)
 	)
 }
 
-func (li *launchpadImporter) ImportAll(repo *cache.RepoCache, since time.Time) error {
+func (li *launchpadImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, since time.Time) (<-chan core.ImportResult, error) {
+	out := make(chan core.ImportResult)
 	lpAPI := new(launchpadAPI)
 
 	err := lpAPI.Init()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	lpBugs, err := lpAPI.SearchTasks(li.conf["project"])
+	lpBugs, err := lpAPI.SearchTasks(ctx, li.conf["project"])
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for _, lpBug := range lpBugs {
-		var b *cache.BugCache
-		var err error
+	go func() {
+		for _, lpBug := range lpBugs {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				lpBugID := fmt.Sprintf("%d", lpBug.ID)
+				b, err := repo.ResolveBugCreateMetadata(keyLaunchpadID, lpBugID)
+				if err != nil && err != bug.ErrBugNotExist {
+					out <- core.NewImportError(err, entity.Id(lpBugID))
+					return
+				}
 
-		lpBugID := fmt.Sprintf("%d", lpBug.ID)
-		b, err = repo.ResolveBugCreateMetadata(keyLaunchpadID, lpBugID)
-		if err != nil && err != bug.ErrBugNotExist {
-			return err
-		}
+				owner, err := li.ensurePerson(repo, lpBug.Owner)
+				if err != nil {
+					out <- core.NewImportError(err, entity.Id(lpBugID))
+					return
+				}
 
-		owner, err := li.ensurePerson(repo, lpBug.Owner)
-		if err != nil {
-			return err
-		}
+				if err == bug.ErrBugNotExist {
+					createdAt, _ := time.Parse(time.RFC3339, lpBug.CreatedAt)
+					b, _, err = repo.NewBugRaw(
+						owner,
+						createdAt.Unix(),
+						lpBug.Title,
+						lpBug.Description,
+						nil,
+						map[string]string{
+							keyLaunchpadID: lpBugID,
+						},
+					)
+					if err != nil {
+						out <- core.NewImportError(err, entity.Id(lpBugID))
+						return
+					}
 
-		if err == bug.ErrBugNotExist {
-			createdAt, _ := time.Parse(time.RFC3339, lpBug.CreatedAt)
-			b, _, err = repo.NewBugRaw(
-				owner,
-				createdAt.Unix(),
-				lpBug.Title,
-				lpBug.Description,
-				nil,
-				map[string]string{
-					keyLaunchpadID: lpBugID,
-				},
-			)
-			if err != nil {
-				return errors.Wrapf(err, "failed to add bug id #%s", lpBugID)
+					out <- core.NewImportBug(b.Id())
+
+				}
+
+				/* Handle messages */
+				if len(lpBug.Messages) == 0 {
+					err := fmt.Sprintf("bug doesn't have any comments")
+					out <- core.NewImportNothing(entity.Id(lpBugID), err)
+					return
+				}
+
+				// The Launchpad API returns the bug description as the first
+				// comment, so skip it.
+				for _, lpMessage := range lpBug.Messages[1:] {
+					_, err := b.ResolveOperationWithMetadata(keyLaunchpadID, lpMessage.ID)
+					if err != nil && err != cache.ErrNoMatchingOp {
+						out <- core.NewImportError(err, entity.Id(lpMessage.ID))
+						return
+					}
+
+					// If this comment already exists, we are probably
+					// updating an existing bug. We do not want to duplicate
+					// the comments, so let us just skip this one.
+					// TODO: Can Launchpad comments be edited?
+					if err == nil {
+						continue
+					}
+
+					owner, err := li.ensurePerson(repo, lpMessage.Owner)
+					if err != nil {
+						out <- core.NewImportError(err, "")
+						return
+					}
+
+					// This is a new comment, we can add it.
+					createdAt, _ := time.Parse(time.RFC3339, lpMessage.CreatedAt)
+					op, err := b.AddCommentRaw(
+						owner,
+						createdAt.Unix(),
+						lpMessage.Content,
+						nil,
+						map[string]string{
+							keyLaunchpadID: lpMessage.ID,
+						})
+					if err != nil {
+						out <- core.NewImportError(err, op.Id())
+						return
+					}
+
+					out <- core.NewImportComment(op.Id())
+				}
+
+				err = b.CommitAsNeeded()
+				if err != nil {
+					out <- core.NewImportError(err, "")
+					return
+				}
 			}
-		} else {
-			/* TODO: Update bug */
-			fmt.Println("TODO: Update bug")
 		}
+	}()
 
-		/* Handle messages */
-		if len(lpBug.Messages) == 0 {
-			return errors.Wrapf(err, "failed to fetch comments for bug #%s", lpBugID)
-		}
-
-		// The Launchpad API returns the bug description as the first
-		// comment, so skip it.
-		for _, lpMessage := range lpBug.Messages[1:] {
-			_, err := b.ResolveOperationWithMetadata(keyLaunchpadID, lpMessage.ID)
-			if err != nil && err != cache.ErrNoMatchingOp {
-				return errors.Wrapf(err, "failed to fetch comments for bug #%s", lpBugID)
-			}
-
-			// If this comment already exists, we are probably
-			// updating an existing bug. We do not want to duplicate
-			// the comments, so let us just skip this one.
-			// TODO: Can Launchpad comments be edited?
-			if err == nil {
-				continue
-			}
-
-			owner, err := li.ensurePerson(repo, lpMessage.Owner)
-			if err != nil {
-				return err
-			}
-
-			// This is a new comment, we can add it.
-			createdAt, _ := time.Parse(time.RFC3339, lpMessage.CreatedAt)
-			_, err = b.AddCommentRaw(
-				owner,
-				createdAt.Unix(),
-				lpMessage.Content,
-				nil,
-				map[string]string{
-					keyLaunchpadID: lpMessage.ID,
-				})
-			if err != nil {
-				return errors.Wrapf(err, "failed to add comment to bug #%s", lpBugID)
-			}
-		}
-		err = b.CommitAsNeeded()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return out, nil
 }

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -172,18 +172,10 @@ func (c *RepoCache) lock() error {
 }
 
 func (c *RepoCache) Close() error {
-	for id := range c.identities {
-		delete(c.identities, id)
-	}
-	for id := range c.identitiesExcerpts {
-		delete(c.identitiesExcerpts, id)
-	}
-	for id := range c.bugs {
-		delete(c.bugs, id)
-	}
-	for id := range c.bugExcerpts {
-		delete(c.bugExcerpts, id)
-	}
+	c.identities = make(map[entity.Id]*IdentityCache)
+	c.identitiesExcerpts = nil
+	c.bugs = make(map[entity.Id]*BugCache)
+	c.bugExcerpts = nil
 
 	lockPath := repoLockFilePath(c.repo)
 	return os.Remove(lockPath)

--- a/commands/bridge_pull.go
+++ b/commands/bridge_pull.go
@@ -1,6 +1,10 @@
 package commands
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,11 +35,58 @@ func runBridgePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	parentCtx := context.Background()
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	// buffered channel to avoid send block at the end
+	done := make(chan struct{}, 1)
+
+	var mu sync.Mutex
+	interruptCount := 0
+	interrupt.RegisterCleaner(func() error {
+		mu.Lock()
+		if interruptCount > 0 {
+			fmt.Println("Received another interrupt before graceful stop, terminating...")
+			os.Exit(0)
+		}
+
+		interruptCount++
+		mu.Unlock()
+
+		fmt.Println("Received interrupt signal, stopping the import...\n(Hit ctrl-c again to kill the process.)")
+
+		// send signal to stop the importer
+		cancel()
+
+		// block until importer gracefully shutdown
+		<-done
+		return nil
+	})
+
 	// TODO: by default import only new events
-	err = b.ImportAll(time.Time{})
+	events, err := b.ImportAll(ctx, time.Time{})
 	if err != nil {
 		return err
 	}
+
+	importedIssues := 0
+	importedIdentities := 0
+	for result := range events {
+		fmt.Println(result.String())
+
+		switch result.Event {
+		case core.ImportEventBug:
+			importedIssues++
+		case core.ImportEventIdentity:
+			importedIdentities++
+		}
+	}
+
+	// send done signal
+	close(done)
+
+	fmt.Printf("Successfully imported %d issues and %d identities with %s bridge\n", importedIssues, importedIdentities, b.Name)
 
 	return nil
 }

--- a/commands/bridge_pull.go
+++ b/commands/bridge_pull.go
@@ -73,7 +73,9 @@ func runBridgePull(cmd *cobra.Command, args []string) error {
 	importedIssues := 0
 	importedIdentities := 0
 	for result := range events {
-		fmt.Println(result.String())
+		if result.Event != core.ImportEventNothing {
+			fmt.Println(result.String())
+		}
 
 		switch result.Event {
 		case core.ImportEventBug:

--- a/commands/bridge_push.go
+++ b/commands/bridge_push.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,19 +35,54 @@ func runBridgePush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	parentCtx := context.Background()
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	done := make(chan struct{}, 1)
+
+	var mu sync.Mutex
+	interruptCount := 0
+	interrupt.RegisterCleaner(func() error {
+		mu.Lock()
+		if interruptCount > 0 {
+			fmt.Println("Received another interrupt before graceful stop, terminating...")
+			os.Exit(0)
+		}
+
+		interruptCount++
+		mu.Unlock()
+
+		fmt.Println("Received interrupt signal, stopping the import...\n(Hit ctrl-c again to kill the process.)")
+
+		// send signal to stop the importer
+		cancel()
+
+		// block until importer gracefully shutdown
+		<-done
+		return nil
+	})
+
 	// TODO: by default export only new events
-	out, err := b.ExportAll(time.Time{})
+	events, err := b.ExportAll(ctx, time.Time{})
 	if err != nil {
 		return err
 	}
 
-	for result := range out {
-		if result.Err != nil {
-			fmt.Println(result.Err, result.Reason)
-		} else {
-			fmt.Printf("%s: %s\n", result.String(), result.ID)
+	exportedIssues := 0
+	for result := range events {
+		fmt.Println(result.String())
+
+		switch result.Event {
+		case core.ExportEventBug:
+			exportedIssues++
 		}
 	}
+
+	// send done signal
+	close(done)
+
+	fmt.Printf("Successfully exported %d issues with %s bridge\n", exportedIssues, b.Name)
 
 	return nil
 }

--- a/commands/bridge_push.go
+++ b/commands/bridge_push.go
@@ -71,7 +71,9 @@ func runBridgePush(cmd *cobra.Command, args []string) error {
 
 	exportedIssues := 0
 	for result := range events {
-		fmt.Println(result.String())
+		if result.Event != core.ExportEventNothing {
+			fmt.Println(result.String())
+		}
 
 		switch result.Event {
 		case core.ExportEventBug:

--- a/entity/merge.go
+++ b/entity/merge.go
@@ -13,6 +13,7 @@ const (
 	MergeStatusInvalid
 	MergeStatusUpdated
 	MergeStatusNothing
+	MergeStatusError
 )
 
 type MergeResult struct {
@@ -39,6 +40,8 @@ func (mr MergeResult) String() string {
 		return "updated"
 	case MergeStatusNothing:
 		return "nothing to do"
+	case MergeStatusError:
+		return fmt.Sprintf("merge error on %s: %s", mr.Id, mr.Err.Error())
 	default:
 		panic("unknown merge status")
 	}
@@ -46,8 +49,9 @@ func (mr MergeResult) String() string {
 
 func NewMergeError(err error, id Id) MergeResult {
 	return MergeResult{
-		Err: err,
-		Id:  id,
+		Err:    err,
+		Id:     id,
+		Status: MergeStatusError,
 	}
 }
 

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
- [x] changes for the `Importer` and `Exporter` interfaces
- [x] Add ImportEvents functionalities to `core` package
- [x] Use a global context for the bridge importer and exporter
- [x] gracefull kill on bridge pull/push commands 
- [x] improve bridge pull/push events logging
- [x] analyse the events to print statistics at the end of pull/push 
fix #175 