### PR TITLE
bridge: Github exporter support case sensitive labels

### DIFF
--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -55,6 +55,12 @@ func testCases(t *testing.T, repo *cache.RepoCache, identity *cache.IdentityCach
 	_, _, err = bugLabelChange.ChangeLabels(nil, []string{"bug"})
 	require.NoError(t, err)
 
+	_, _, err = bugLabelChange.ChangeLabels([]string{"InVaLiD"}, nil)
+	require.NoError(t, err)
+
+	_, _, err = bugLabelChange.ChangeLabels([]string{"bUG"}, nil)
+	require.NoError(t, err)
+
 	// bug with comments editions
 	bugWithCommentEditions, createOp, err := repo.NewBug("bug with comments editions", "new bug")
 	require.NoError(t, err)
@@ -99,7 +105,7 @@ func testCases(t *testing.T, repo *cache.RepoCache, identity *cache.IdentityCach
 		&testCase{
 			name:    "bug label change",
 			bug:     bugLabelChange,
-			numOrOp: 4,
+			numOrOp: 6,
 		},
 		&testCase{
 			name:    "bug with comment editions",

--- a/bridge/github/import_query.go
+++ b/bridge/github/import_query.go
@@ -175,3 +175,17 @@ type labelQuery struct {
 		} `graphql:"label(name: $label)"`
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
+
+type labelsQuery struct {
+	Repository struct {
+		Labels struct {
+			Nodes []struct {
+				ID          string `graphql:"id"`
+				Name        string `graphql:"name"`
+				Color       string `graphql:"color"`
+				Description string `graphql:"description"`
+			}
+			PageInfo pageInfo
+		} `graphql:"labels(first: $first, after: $after)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}


### PR DESCRIPTION
- import all existing labels at Github before start export task
- fix #176 