### PR TITLE
Future proof the operation's ID

### DIFF
--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -1,6 +1,10 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/MichaelMure/git-bug/entity"
+)
 
 type ExportEvent int
 
@@ -21,7 +25,7 @@ const (
 type ExportResult struct {
 	Err    error
 	Event  ExportEvent
-	ID     string
+	ID     entity.Id
 	Reason string
 }
 
@@ -46,14 +50,14 @@ func (er ExportResult) String() string {
 	}
 }
 
-func NewExportError(err error, reason string) ExportResult {
+func NewExportError(err error, id entity.Id) ExportResult {
 	return ExportResult{
-		Err:    err,
-		Reason: reason,
+		ID:  id,
+		Err: err,
 	}
 }
 
-func NewExportNothing(id string, reason string) ExportResult {
+func NewExportNothing(id entity.Id, reason string) ExportResult {
 	return ExportResult{
 		ID:     id,
 		Reason: reason,
@@ -61,42 +65,42 @@ func NewExportNothing(id string, reason string) ExportResult {
 	}
 }
 
-func NewExportBug(id string) ExportResult {
+func NewExportBug(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventBug,
 	}
 }
 
-func NewExportComment(id string) ExportResult {
+func NewExportComment(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventComment,
 	}
 }
 
-func NewExportCommentEdition(id string) ExportResult {
+func NewExportCommentEdition(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventCommentEdition,
 	}
 }
 
-func NewExportStatusChange(id string) ExportResult {
+func NewExportStatusChange(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventStatusChange,
 	}
 }
 
-func NewExportLabelChange(id string) ExportResult {
+func NewExportLabelChange(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventLabelChange,
 	}
 }
 
-func NewExportTitleEdition(id string) ExportResult {
+func NewExportTitleEdition(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventTitleEdition,

--- a/bridge/github/export.go
+++ b/bridge/github/export.go
@@ -290,7 +290,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 			} else {
 
 				// case comment edition operation: we need to edit the Github comment
-				commentID, ok := ge.cachedOperationIDs[opr.ID()]
+				commentID, ok := ge.cachedOperationIDs[opr.Target]
 				if !ok {
 					panic("unexpected error: comment id not found")
 				}

--- a/bridge/github/export.go
+++ b/bridge/github/export.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 var (
@@ -28,17 +29,17 @@ type githubExporter struct {
 	conf core.Configuration
 
 	// cache identities clients
-	identityClient map[string]*githubv4.Client
+	identityClient map[entity.Id]*githubv4.Client
 
 	// map identities with their tokens
-	identityToken map[string]string
+	identityToken map[entity.Id]string
 
 	// github repository ID
 	repositoryID string
 
 	// cache identifiers used to speed up exporting operations
 	// cleared for each bug
-	cachedOperationIDs map[string]string
+	cachedOperationIDs map[entity.Id]string
 
 	// cache labels used to speed up exporting labels events
 	cachedLabels map[string]string
@@ -48,16 +49,16 @@ type githubExporter struct {
 func (ge *githubExporter) Init(conf core.Configuration) error {
 	ge.conf = conf
 	//TODO: initialize with multiple tokens
-	ge.identityToken = make(map[string]string)
-	ge.identityClient = make(map[string]*githubv4.Client)
-	ge.cachedOperationIDs = make(map[string]string)
+	ge.identityToken = make(map[entity.Id]string)
+	ge.identityClient = make(map[entity.Id]*githubv4.Client)
+	ge.cachedOperationIDs = make(map[entity.Id]string)
 	ge.cachedLabels = make(map[string]string)
 	return nil
 }
 
 // getIdentityClient return a githubv4 API client configured with the access token of the given identity.
 // if no client were found it will initialize it from the known tokens map and cache it for next use
-func (ge *githubExporter) getIdentityClient(id string) (*githubv4.Client, error) {
+func (ge *githubExporter) getIdentityClient(id entity.Id) (*githubv4.Client, error) {
 	client, ok := ge.identityClient[id]
 	if ok {
 		return client, nil
@@ -102,7 +103,7 @@ func (ge *githubExporter) ExportAll(repo *cache.RepoCache, since time.Time) (<-c
 	go func() {
 		defer close(out)
 
-		var allIdentitiesIds []string
+		var allIdentitiesIds []entity.Id
 		for id := range ge.identityToken {
 			allIdentitiesIds = append(allIdentitiesIds, id)
 		}
@@ -112,7 +113,7 @@ func (ge *githubExporter) ExportAll(repo *cache.RepoCache, since time.Time) (<-c
 		for _, id := range allBugsIds {
 			b, err := repo.ResolveBug(id)
 			if err != nil {
-				out <- core.NewExportError(err, id)
+				out <- core.NewExportError(errors.Wrap(err, "can't load bug"), id)
 				return
 			}
 
@@ -165,7 +166,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 		githubURL, ok := snapshot.GetCreateMetadata(keyGithubUrl)
 		if !ok {
 			// if we find github ID, github URL must be found too
-			err := fmt.Errorf("expected to find github issue URL")
+			err := fmt.Errorf("incomplete Github metadata: expected to find issue URL")
 			out <- core.NewExportError(err, b.Id())
 		}
 
@@ -208,7 +209,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 		out <- core.NewExportBug(b.Id())
 
 		// mark bug creation operation as exported
-		if err := markOperationAsExported(b, createOp.ID(), id, url); err != nil {
+		if err := markOperationAsExported(b, createOp.Id(), id, url); err != nil {
 			err := errors.Wrap(err, "marking operation as exported")
 			out <- core.NewExportError(err, b.Id())
 			return
@@ -227,7 +228,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 	}
 
 	// cache operation github id
-	ge.cachedOperationIDs[createOp.ID()] = bugGithubID
+	ge.cachedOperationIDs[createOp.Id()] = bugGithubID
 
 	for _, op := range snapshot.Operations[1:] {
 		// ignore SetMetadata operations
@@ -238,15 +239,15 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 		// ignore operations already existing in github (due to import or export)
 		// cache the ID of already exported or imported issues and events from Github
 		if id, ok := op.GetMetadata(keyGithubId); ok {
-			ge.cachedOperationIDs[op.ID()] = id
-			out <- core.NewExportNothing(op.ID(), "already exported operation")
+			ge.cachedOperationIDs[op.Id()] = id
+			out <- core.NewExportNothing(op.Id(), "already exported operation")
 			continue
 		}
 
 		opAuthor := op.GetAuthor()
 		client, err := ge.getIdentityClient(opAuthor.Id())
 		if err != nil {
-			out <- core.NewExportNothing(op.ID(), "missing operation author token")
+			out <- core.NewExportNothing(op.Id(), "missing operation author token")
 			continue
 		}
 
@@ -263,17 +264,17 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 				return
 			}
 
-			out <- core.NewExportComment(op.ID())
+			out <- core.NewExportComment(op.Id())
 
 			// cache comment id
-			ge.cachedOperationIDs[op.ID()] = id
+			ge.cachedOperationIDs[op.Id()] = id
 
 		case *bug.EditCommentOperation:
 
 			opr := op.(*bug.EditCommentOperation)
 
 			// Since github doesn't consider the issue body as a comment
-			if opr.Target == createOp.ID() {
+			if opr.Target == createOp.Id() {
 
 				// case bug creation operation: we need to edit the Github issue
 				if err := updateGithubIssueBody(client, bugGithubID, opr.Message); err != nil {
@@ -282,7 +283,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 					return
 				}
 
-				out <- core.NewExportCommentEdition(op.ID())
+				out <- core.NewExportCommentEdition(op.Id())
 
 				id = bugGithubID
 				url = bugGithubURL
@@ -302,7 +303,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 					return
 				}
 
-				out <- core.NewExportCommentEdition(op.ID())
+				out <- core.NewExportCommentEdition(op.Id())
 
 				// use comment id/url instead of issue id/url
 				id = eid
@@ -317,7 +318,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 				return
 			}
 
-			out <- core.NewExportStatusChange(op.ID())
+			out <- core.NewExportStatusChange(op.Id())
 
 			id = bugGithubID
 			url = bugGithubURL
@@ -330,7 +331,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 				return
 			}
 
-			out <- core.NewExportTitleEdition(op.ID())
+			out <- core.NewExportTitleEdition(op.Id())
 
 			id = bugGithubID
 			url = bugGithubURL
@@ -343,7 +344,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 				return
 			}
 
-			out <- core.NewExportLabelChange(op.ID())
+			out <- core.NewExportLabelChange(op.Id())
 
 			id = bugGithubID
 			url = bugGithubURL
@@ -353,7 +354,7 @@ func (ge *githubExporter) exportBug(b *cache.BugCache, since time.Time, out chan
 		}
 
 		// mark operation as exported
-		if err := markOperationAsExported(b, op.ID(), id, url); err != nil {
+		if err := markOperationAsExported(b, op.Id(), id, url); err != nil {
 			err := errors.Wrap(err, "marking operation as exported")
 			out <- core.NewExportError(err, b.Id())
 			return
@@ -411,7 +412,7 @@ func getRepositoryNodeID(owner, project, token string) (string, error) {
 	return aux.NodeID, nil
 }
 
-func markOperationAsExported(b *cache.BugCache, target string, githubID, githubURL string) error {
+func markOperationAsExported(b *cache.BugCache, target entity.Id, githubID, githubURL string) error {
 	_, err := b.SetMetadata(
 		target,
 		map[string]string{

--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -58,13 +58,13 @@ func testCases(t *testing.T, repo *cache.RepoCache, identity *cache.IdentityCach
 	bugWithCommentEditions, createOp, err := repo.NewBug("bug with comments editions", "new bug")
 	require.NoError(t, err)
 
-	_, err = bugWithCommentEditions.EditComment(createOp.ID(), "first comment edited")
+	_, err = bugWithCommentEditions.EditComment(createOp.Id(), "first comment edited")
 	require.NoError(t, err)
 
 	commentOp, err := bugWithCommentEditions.AddComment("first comment")
 	require.NoError(t, err)
 
-	_, err = bugWithCommentEditions.EditComment(commentOp.ID(), "first comment edited")
+	_, err = bugWithCommentEditions.EditComment(commentOp.Id(), "first comment edited")
 	require.NoError(t, err)
 
 	// bug status changed

--- a/bridge/github/export_test.go
+++ b/bridge/github/export_test.go
@@ -58,19 +58,13 @@ func testCases(t *testing.T, repo *cache.RepoCache, identity *cache.IdentityCach
 	bugWithCommentEditions, createOp, err := repo.NewBug("bug with comments editions", "new bug")
 	require.NoError(t, err)
 
-	createOpHash, err := createOp.Hash()
-	require.NoError(t, err)
-
-	_, err = bugWithCommentEditions.EditComment(createOpHash, "first comment edited")
+	_, err = bugWithCommentEditions.EditComment(createOp.ID(), "first comment edited")
 	require.NoError(t, err)
 
 	commentOp, err := bugWithCommentEditions.AddComment("first comment")
 	require.NoError(t, err)
 
-	commentOpHash, err := commentOp.Hash()
-	require.NoError(t, err)
-
-	_, err = bugWithCommentEditions.EditComment(commentOpHash, "first comment edited")
+	_, err = bugWithCommentEditions.EditComment(commentOp.ID(), "first comment edited")
 	require.NoError(t, err)
 
 	// bug status changed

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -10,7 +10,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/identity"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -369,7 +369,7 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 				}
 
 				// set target for the nexr edit now that the comment is created
-				targetOpID = op.ID()
+				targetOpID = op.Id()
 
 				continue
 			}
@@ -383,7 +383,7 @@ func (gi *githubImporter) ensureTimelineComment(repo *cache.RepoCache, b *cache.
 	return nil
 }
 
-func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugCache, target string, edit userContentEdit) error {
+func (gi *githubImporter) ensureCommentEdit(repo *cache.RepoCache, b *cache.BugCache, target entity.Id, edit userContentEdit) error {
 	_, err := b.ResolveOperationWithMetadata(keyGithubId, parseId(edit.Id))
 	if err == nil {
 		// already imported
@@ -445,7 +445,7 @@ func (gi *githubImporter) ensurePerson(repo *cache.RepoCache, actor *actor) (*ca
 	if err == nil {
 		return i, nil
 	}
-	if _, ok := err.(identity.ErrMultipleMatch); ok {
+	if _, ok := err.(entity.ErrMultipleMatch); ok {
 		return nil, err
 	}
 
@@ -488,7 +488,7 @@ func (gi *githubImporter) getGhost(repo *cache.RepoCache) (*cache.IdentityCache,
 	if err == nil {
 		return i, nil
 	}
-	if _, ok := err.(identity.ErrMultipleMatch); ok {
+	if _, ok := err.(entity.ErrMultipleMatch); ok {
 		return nil, err
 	}
 

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -132,7 +132,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 	gitlabID := parseID(note.ID)
 
 	id, errResolve := b.ResolveOperationWithMetadata(keyGitlabId, gitlabID)
-	if errResolve != cache.ErrNoMatchingOp {
+	if errResolve != nil && errResolve != cache.ErrNoMatchingOp {
 		return errResolve
 	}
 

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -11,7 +11,6 @@ import (
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/identity"
-	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -130,10 +129,10 @@ func (gi *gitlabImporter) ensureIssue(repo *cache.RepoCache, issue *gitlab.Issue
 }
 
 func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, note *gitlab.Note) error {
-	id := parseID(note.ID)
+	gitlabID := parseID(note.ID)
 
-	hash, errResolve := b.ResolveOperationWithMetadata(keyGitlabId, id)
-	if errResolve != nil && errResolve != cache.ErrNoMatchingOp {
+	id, errResolve := b.ResolveOperationWithMetadata(keyGitlabId, gitlabID)
+	if errResolve != cache.ErrNoMatchingOp {
 		return errResolve
 	}
 
@@ -154,7 +153,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			author,
 			note.CreatedAt.Unix(),
 			map[string]string{
-				keyGitlabId: id,
+				keyGitlabId: gitlabID,
 			},
 		)
 		return err
@@ -168,7 +167,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			author,
 			note.CreatedAt.Unix(),
 			map[string]string{
-				keyGitlabId: id,
+				keyGitlabId: gitlabID,
 			},
 		)
 		return err
@@ -185,10 +184,10 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			_, err = b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
-				git.Hash(firstComment.Id()),
+				firstComment.Id(),
 				issue.Description,
 				map[string]string{
-					keyGitlabId: id,
+					keyGitlabId: gitlabID,
 				},
 			)
 
@@ -211,7 +210,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 				cleanText,
 				nil,
 				map[string]string{
-					keyGitlabId: id,
+					keyGitlabId: gitlabID,
 				},
 			)
 
@@ -221,7 +220,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// if comment was already exported
 
 		// search for last comment update
-		comment, err := b.Snapshot().SearchComment(hash)
+		comment, err := b.Snapshot().SearchComment(id)
 		if err != nil {
 			return err
 		}
@@ -232,7 +231,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			_, err = b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
-				git.Hash(comment.Id()),
+				comment.Id(),
 				cleanText,
 				nil,
 			)
@@ -253,7 +252,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			note.CreatedAt.Unix(),
 			body,
 			map[string]string{
-				keyGitlabId: id,
+				keyGitlabId: gitlabID,
 			},
 		)
 

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -10,7 +10,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/identity"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -324,7 +324,7 @@ func (gi *gitlabImporter) ensurePerson(repo *cache.RepoCache, id int) (*cache.Id
 	if err == nil {
 		return i, nil
 	}
-	if _, ok := err.(identity.ErrMultipleMatch); ok {
+	if _, ok := err.(entity.ErrMultipleMatch); ok {
 		return nil, err
 	}
 

--- a/bridge/launchpad/import.go
+++ b/bridge/launchpad/import.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/identity"
-	"github.com/pkg/errors"
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 type launchpadImporter struct {
@@ -29,7 +30,7 @@ func (li *launchpadImporter) ensurePerson(repo *cache.RepoCache, owner LPPerson)
 	if err == nil {
 		return i, nil
 	}
-	if _, ok := err.(identity.ErrMultipleMatch); ok {
+	if _, ok := err.(entity.ErrMultipleMatch); ok {
 		return nil, err
 	}
 

--- a/bug/bug.go
+++ b/bug/bug.go
@@ -29,18 +29,12 @@ const editClockEntryPattern = "edit-clock-%d"
 
 var ErrBugNotExist = errors.New("bug doesn't exist")
 
-type ErrMultipleMatch struct {
-	Matching []entity.Id
+func NewErrMultipleMatchBug(matching []entity.Id) *entity.ErrMultipleMatch {
+	return entity.NewErrMultipleMatch("bug", matching)
 }
 
-func (e ErrMultipleMatch) Error() string {
-	matching := make([]string, len(e.Matching))
-
-	for i, match := range e.Matching {
-		matching[i] = match.String()
-	}
-
-	return fmt.Sprintf("Multiple matching bug found:\n%s", strings.Join(matching, "\n"))
+func NewErrMultipleMatchOp(matching []entity.Id) *entity.ErrMultipleMatch {
+	return entity.NewErrMultipleMatch("operation", matching)
 }
 
 var _ Interface = &Bug{}
@@ -100,7 +94,7 @@ func FindLocalBug(repo repository.ClockedRepo, prefix string) (*Bug, error) {
 	}
 
 	if len(matching) > 1 {
-		return nil, ErrMultipleMatch{Matching: matching}
+		return nil, NewErrMultipleMatchBug(matching)
 	}
 
 	return ReadLocalBug(repo, matching[0])

--- a/bug/bug_actions.go
+++ b/bug/bug_actions.go
@@ -81,7 +81,7 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 				continue
 			}
 
-			localRef := bugsRefPattern + remoteBug.Id()
+			localRef := bugsRefPattern + remoteBug.Id().String()
 			localExist, err := repo.RefExist(localRef)
 
 			if err != nil {

--- a/bug/bug_actions.go
+++ b/bug/bug_actions.go
@@ -65,8 +65,13 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		}
 
 		for _, remoteRef := range remoteRefs {
-			refSplitted := strings.Split(remoteRef, "/")
-			id := refSplitted[len(refSplitted)-1]
+			refSplit := strings.Split(remoteRef, "/")
+			id := entity.Id(refSplit[len(refSplit)-1])
+
+			if err := id.Validate(); err != nil {
+				out <- entity.NewMergeInvalidStatus(id, errors.Wrap(err, "invalid ref").Error())
+				continue
+			}
 
 			remoteBug, err := readBug(repo, remoteRef)
 

--- a/bug/bug_test.go
+++ b/bug/bug_test.go
@@ -103,7 +103,7 @@ func equivalentBug(t *testing.T, expected, actual *Bug) {
 
 	for i := range expected.packs {
 		for j := range expected.packs[i].Operations {
-			actual.packs[i].Operations[j].base().hash = expected.packs[i].Operations[j].base().hash
+			actual.packs[i].Operations[j].base().id = expected.packs[i].Operations[j].base().id
 		}
 	}
 

--- a/bug/comment.go
+++ b/bug/comment.go
@@ -1,6 +1,7 @@
 package bug
 
 import (
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/git-bug/util/timestamp"
@@ -9,7 +10,7 @@ import (
 
 // Comment represent a comment in a Bug
 type Comment struct {
-	id      string
+	id      entity.Id
 	Author  identity.Interface
 	Message string
 	Files   []git.Hash
@@ -20,18 +21,13 @@ type Comment struct {
 }
 
 // Id return the Comment identifier
-func (c Comment) Id() string {
+func (c Comment) Id() entity.Id {
 	if c.id == "" {
 		// simply panic as it would be a coding error
 		// (using an id of an identity not stored yet)
 		panic("no id yet")
 	}
 	return c.id
-}
-
-// HumanId return the Comment identifier truncated for human consumption
-func (c Comment) HumanId() string {
-	return FormatHumanID(c.Id())
 }
 
 // FormatTimeRel format the UnixTime of the comment for human consumption

--- a/bug/interface.go
+++ b/bug/interface.go
@@ -1,16 +1,14 @@
 package bug
 
 import (
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/lamport"
 )
 
 type Interface interface {
 	// Id return the Bug identifier
-	Id() string
-
-	// HumanId return the Bug identifier truncated for human consumption
-	HumanId() string
+	Id() entity.Id
 
 	// Validate check if the Bug data is valid
 	Validate() error

--- a/bug/op_add_comment.go
+++ b/bug/op_add_comment.go
@@ -24,23 +24,16 @@ func (op *AddCommentOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *AddCommentOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *AddCommentOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *AddCommentOperation) Apply(snapshot *Snapshot) {
 	snapshot.addActor(op.Author)
 	snapshot.addParticipant(op.Author)
 
-	hash, err := op.Hash()
-	if err != nil {
-		// Should never error unless a programming error happened
-		// (covered in OpBase.Validate())
-		panic(err)
-	}
-
 	comment := Comment{
-		id:       string(hash),
+		id:       op.ID(),
 		Message:  op.Message,
 		Author:   op.Author,
 		Files:    op.Files,
@@ -50,7 +43,7 @@ func (op *AddCommentOperation) Apply(snapshot *Snapshot) {
 	snapshot.Comments = append(snapshot.Comments, comment)
 
 	item := &AddCommentTimelineItem{
-		CommentTimelineItem: NewCommentTimelineItem(hash, comment),
+		CommentTimelineItem: NewCommentTimelineItem(op.ID(), comment),
 	}
 
 	snapshot.Timeline = append(snapshot.Timeline, item)

--- a/bug/op_add_comment_test.go
+++ b/bug/op_add_comment_test.go
@@ -2,6 +2,7 @@ package bug
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,8 +22,9 @@ func TestAddCommentSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_add_comment_test.go
+++ b/bug/op_add_comment_test.go
@@ -21,5 +21,8 @@ func TestAddCommentSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the ID
+	before.ID()
+
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_add_comment_test.go
+++ b/bug/op_add_comment_test.go
@@ -2,12 +2,12 @@ package bug
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/MichaelMure/git-bug/identity"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/MichaelMure/git-bug/identity"
 )
 
 func TestAddCommentSerialize(t *testing.T) {

--- a/bug/op_create.go
+++ b/bug/op_create.go
@@ -25,25 +25,18 @@ func (op *CreateOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *CreateOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *CreateOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *CreateOperation) Apply(snapshot *Snapshot) {
 	snapshot.addActor(op.Author)
 	snapshot.addParticipant(op.Author)
 
-	hash, err := op.Hash()
-	if err != nil {
-		// Should never error unless a programming error happened
-		// (covered in OpBase.Validate())
-		panic(err)
-	}
-
 	snapshot.Title = op.Title
 
 	comment := Comment{
-		id:       string(hash),
+		id:       op.ID(),
 		Message:  op.Message,
 		Author:   op.Author,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
@@ -55,7 +48,7 @@ func (op *CreateOperation) Apply(snapshot *Snapshot) {
 
 	snapshot.Timeline = []TimelineItem{
 		&CreateTimelineItem{
-			CommentTimelineItem: NewCommentTimelineItem(hash, comment),
+			CommentTimelineItem: NewCommentTimelineItem(op.ID(), comment),
 		},
 	}
 }

--- a/bug/op_create_test.go
+++ b/bug/op_create_test.go
@@ -20,11 +20,11 @@ func TestCreate(t *testing.T) {
 
 	create.Apply(&snapshot)
 
-	hash, err := create.Hash()
-	assert.NoError(t, err)
+	id := create.ID()
+	assert.True(t, IDIsValid(id))
 
 	comment := Comment{
-		id:       string(hash),
+		id:       string(id),
 		Author:   rene,
 		Message:  "message",
 		UnixTime: timestamp.Timestamp(create.UnixTime),
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 		CreatedAt:    create.Time(),
 		Timeline: []TimelineItem{
 			&CreateTimelineItem{
-				CommentTimelineItem: NewCommentTimelineItem(hash, comment),
+				CommentTimelineItem: NewCommentTimelineItem(id, comment),
 			},
 		},
 	}
@@ -60,6 +60,9 @@ func TestCreateSerialize(t *testing.T) {
 	var after CreateOperation
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
+
+	// enforce creating the ID
+	before.ID()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_create_test.go
+++ b/bug/op_create_test.go
@@ -20,11 +20,11 @@ func TestCreate(t *testing.T) {
 
 	create.Apply(&snapshot)
 
-	id := create.ID()
-	assert.True(t, IDIsValid(id))
+	id := create.Id()
+	assert.NoError(t, id.Validate())
 
 	comment := Comment{
-		id:       string(id),
+		id:       id,
 		Author:   rene,
 		Message:  "message",
 		UnixTime: timestamp.Timestamp(create.UnixTime),
@@ -61,8 +61,9 @@ func TestCreateSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_edit_comment_test.go
+++ b/bug/op_edit_comment_test.go
@@ -20,14 +20,14 @@ func TestEdit(t *testing.T) {
 	create := NewCreateOp(rene, unix, "title", "create", nil)
 	create.Apply(&snapshot)
 
-	hash1 := create.ID()
-	require.True(t, IDIsValid(hash1))
+	id1 := create.Id()
+	require.NoError(t, id1.Validate())
 
 	comment1 := NewAddCommentOp(rene, unix, "comment 1", nil)
 	comment1.Apply(&snapshot)
 
-	hash2 := comment1.ID()
-	require.True(t, IDIsValid(hash2))
+	id2 := comment1.Id()
+	require.NoError(t, id2.Validate())
 
 	// add another unrelated op in between
 	setTitle := NewSetTitleOp(rene, unix, "edited title", "title")
@@ -36,10 +36,10 @@ func TestEdit(t *testing.T) {
 	comment2 := NewAddCommentOp(rene, unix, "comment 2", nil)
 	comment2.Apply(&snapshot)
 
-	hash3 := comment2.ID()
-	require.True(t, IDIsValid(hash3))
+	id3 := comment2.Id()
+	require.NoError(t, id3.Validate())
 
-	edit := NewEditCommentOp(rene, unix, hash1, "create edited", nil)
+	edit := NewEditCommentOp(rene, unix, id1, "create edited", nil)
 	edit.Apply(&snapshot)
 
 	assert.Equal(t, len(snapshot.Timeline), 4)
@@ -50,7 +50,7 @@ func TestEdit(t *testing.T) {
 	assert.Equal(t, snapshot.Comments[1].Message, "comment 1")
 	assert.Equal(t, snapshot.Comments[2].Message, "comment 2")
 
-	edit2 := NewEditCommentOp(rene, unix, hash2, "comment 1 edited", nil)
+	edit2 := NewEditCommentOp(rene, unix, id2, "comment 1 edited", nil)
 	edit2.Apply(&snapshot)
 
 	assert.Equal(t, len(snapshot.Timeline), 4)
@@ -61,7 +61,7 @@ func TestEdit(t *testing.T) {
 	assert.Equal(t, snapshot.Comments[1].Message, "comment 1 edited")
 	assert.Equal(t, snapshot.Comments[2].Message, "comment 2")
 
-	edit3 := NewEditCommentOp(rene, unix, hash3, "comment 2 edited", nil)
+	edit3 := NewEditCommentOp(rene, unix, id3, "comment 2 edited", nil)
 	edit3.Apply(&snapshot)
 
 	assert.Equal(t, len(snapshot.Timeline), 4)
@@ -85,8 +85,9 @@ func TestEditCommentSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_edit_comment_test.go
+++ b/bug/op_edit_comment_test.go
@@ -20,14 +20,14 @@ func TestEdit(t *testing.T) {
 	create := NewCreateOp(rene, unix, "title", "create", nil)
 	create.Apply(&snapshot)
 
-	hash1, err := create.Hash()
-	require.NoError(t, err)
+	hash1 := create.ID()
+	require.True(t, IDIsValid(hash1))
 
 	comment1 := NewAddCommentOp(rene, unix, "comment 1", nil)
 	comment1.Apply(&snapshot)
 
-	hash2, err := comment1.Hash()
-	require.NoError(t, err)
+	hash2 := comment1.ID()
+	require.True(t, IDIsValid(hash2))
 
 	// add another unrelated op in between
 	setTitle := NewSetTitleOp(rene, unix, "edited title", "title")
@@ -36,8 +36,8 @@ func TestEdit(t *testing.T) {
 	comment2 := NewAddCommentOp(rene, unix, "comment 2", nil)
 	comment2.Apply(&snapshot)
 
-	hash3, err := comment2.Hash()
-	require.NoError(t, err)
+	hash3 := comment2.ID()
+	require.True(t, IDIsValid(hash3))
 
 	edit := NewEditCommentOp(rene, unix, hash1, "create edited", nil)
 	edit.Apply(&snapshot)
@@ -84,6 +84,9 @@ func TestEditCommentSerialize(t *testing.T) {
 	var after EditCommentOperation
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
+
+	// enforce creating the ID
+	before.ID()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_label_change.go
+++ b/bug/op_label_change.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/pkg/errors"
+
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/timestamp"
-
-	"github.com/MichaelMure/git-bug/util/git"
-	"github.com/pkg/errors"
 )
 
 var _ Operation = &LabelChangeOperation{}
@@ -25,8 +24,8 @@ func (op *LabelChangeOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *LabelChangeOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *LabelChangeOperation) ID() string {
+	return idOperation(op)
 }
 
 // Apply apply the operation
@@ -61,15 +60,8 @@ AddLoop:
 		return string(snapshot.Labels[i]) < string(snapshot.Labels[j])
 	})
 
-	hash, err := op.Hash()
-	if err != nil {
-		// Should never error unless a programming error happened
-		// (covered in OpBase.Validate())
-		panic(err)
-	}
-
 	item := &LabelChangeTimelineItem{
-		hash:     hash,
+		id:       op.ID(),
 		Author:   op.Author,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Added:    op.Added,
@@ -163,15 +155,15 @@ func NewLabelChangeOperation(author identity.Interface, unixTime int64, added, r
 }
 
 type LabelChangeTimelineItem struct {
-	hash     git.Hash
+	id       string
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Added    []Label
 	Removed  []Label
 }
 
-func (l LabelChangeTimelineItem) Hash() git.Hash {
-	return l.hash
+func (l LabelChangeTimelineItem) ID() string {
+	return l.id
 }
 
 // Sign post method for gqlgen

--- a/bug/op_label_change_test.go
+++ b/bug/op_label_change_test.go
@@ -21,8 +21,9 @@ func TestLabelChangeSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_label_change_test.go
+++ b/bug/op_label_change_test.go
@@ -21,5 +21,8 @@ func TestLabelChangeSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the ID
+	before.ID()
+
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_noop.go
+++ b/bug/op_noop.go
@@ -3,6 +3,7 @@ package bug
 import (
 	"encoding/json"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 )
 
@@ -19,7 +20,7 @@ func (op *NoOpOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *NoOpOperation) ID() string {
+func (op *NoOpOperation) Id() entity.Id {
 	return idOperation(op)
 }
 
@@ -31,25 +32,9 @@ func (op *NoOpOperation) Validate() error {
 	return opBaseValidate(op, NoOpOp)
 }
 
-// Workaround to avoid the inner OpBase.MarshalJSON overriding the outer op
-// MarshalJSON
-func (op *NoOpOperation) MarshalJSON() ([]byte, error) {
-	base, err := json.Marshal(op.OpBase)
-	if err != nil {
-		return nil, err
-	}
-
-	// revert back to a flat map to be able to add our own fields
-	var data map[string]interface{}
-	if err := json.Unmarshal(base, &data); err != nil {
-		return nil, err
-	}
-
-	return json.Marshal(data)
-}
-
-// Workaround to avoid the inner OpBase.MarshalJSON overriding the outer op
-// MarshalJSON
+// UnmarshalJSON is a two step JSON unmarshaling
+// This workaround is necessary to avoid the inner OpBase.MarshalJSON
+// overriding the outer op's MarshalJSON
 func (op *NoOpOperation) UnmarshalJSON(data []byte) error {
 	// Unmarshal OpBase and the op separately
 

--- a/bug/op_noop.go
+++ b/bug/op_noop.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/MichaelMure/git-bug/identity"
-	"github.com/MichaelMure/git-bug/util/git"
 )
 
 var _ Operation = &NoOpOperation{}
@@ -20,8 +19,8 @@ func (op *NoOpOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *NoOpOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *NoOpOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *NoOpOperation) Apply(snapshot *Snapshot) {

--- a/bug/op_noop_test.go
+++ b/bug/op_noop_test.go
@@ -21,8 +21,9 @@ func TestNoopSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_noop_test.go
+++ b/bug/op_noop_test.go
@@ -21,5 +21,8 @@ func TestNoopSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the ID
+	before.ID()
+
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_metadata.go
+++ b/bug/op_set_metadata.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/identity"
-	"github.com/MichaelMure/git-bug/util/git"
 )
 
 var _ Operation = &SetMetadataOperation{}
 
 type SetMetadataOperation struct {
 	OpBase
-	Target      git.Hash
+	Target      string
 	NewMetadata map[string]string
 }
 
@@ -20,20 +19,13 @@ func (op *SetMetadataOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *SetMetadataOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *SetMetadataOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *SetMetadataOperation) Apply(snapshot *Snapshot) {
 	for _, target := range snapshot.Operations {
-		hash, err := target.Hash()
-		if err != nil {
-			// Should never error unless a programming error happened
-			// (covered in OpBase.Validate())
-			panic(err)
-		}
-
-		if hash == op.Target {
+		if target.ID() == op.Target {
 			base := target.base()
 
 			if base.extraMetadata == nil {
@@ -56,7 +48,7 @@ func (op *SetMetadataOperation) Validate() error {
 		return err
 	}
 
-	if !op.Target.IsValid() {
+	if !IDIsValid(op.Target) {
 		return fmt.Errorf("target hash is invalid")
 	}
 
@@ -95,7 +87,7 @@ func (op *SetMetadataOperation) UnmarshalJSON(data []byte) error {
 	}
 
 	aux := struct {
-		Target      git.Hash          `json:"target"`
+		Target      string            `json:"target"`
 		NewMetadata map[string]string `json:"new_metadata"`
 	}{}
 
@@ -114,7 +106,7 @@ func (op *SetMetadataOperation) UnmarshalJSON(data []byte) error {
 // Sign post method for gqlgen
 func (op *SetMetadataOperation) IsAuthored() {}
 
-func NewSetMetadataOp(author identity.Interface, unixTime int64, target git.Hash, newMetadata map[string]string) *SetMetadataOperation {
+func NewSetMetadataOp(author identity.Interface, unixTime int64, target string, newMetadata map[string]string) *SetMetadataOperation {
 	return &SetMetadataOperation{
 		OpBase:      newOpBase(SetMetadataOp, author, unixTime),
 		Target:      target,
@@ -123,7 +115,7 @@ func NewSetMetadataOp(author identity.Interface, unixTime int64, target git.Hash
 }
 
 // Convenience function to apply the operation
-func SetMetadata(b Interface, author identity.Interface, unixTime int64, target git.Hash, newMetadata map[string]string) (*SetMetadataOperation, error) {
+func SetMetadata(b Interface, author identity.Interface, unixTime int64, target string, newMetadata map[string]string) (*SetMetadataOperation, error) {
 	SetMetadataOp := NewSetMetadataOp(author, unixTime, target, newMetadata)
 	if err := SetMetadataOp.Validate(); err != nil {
 		return nil, err

--- a/bug/op_set_metadata_test.go
+++ b/bug/op_set_metadata_test.go
@@ -21,18 +21,18 @@ func TestSetMetadata(t *testing.T) {
 	create.Apply(&snapshot)
 	snapshot.Operations = append(snapshot.Operations, create)
 
-	hash1 := create.ID()
-	require.True(t, IDIsValid(hash1))
+	id1 := create.Id()
+	require.NoError(t, id1.Validate())
 
 	comment := NewAddCommentOp(rene, unix, "comment", nil)
 	comment.SetMetadata("key2", "value2")
 	comment.Apply(&snapshot)
 	snapshot.Operations = append(snapshot.Operations, comment)
 
-	hash2 := comment.ID()
-	require.True(t, IDIsValid(hash2))
+	id2 := comment.Id()
+	require.NoError(t, id2.Validate())
 
-	op1 := NewSetMetadataOp(rene, unix, hash1, map[string]string{
+	op1 := NewSetMetadataOp(rene, unix, id1, map[string]string{
 		"key":  "override",
 		"key2": "value",
 	})
@@ -51,7 +51,7 @@ func TestSetMetadata(t *testing.T) {
 	assert.Equal(t, len(commentMetadata), 1)
 	assert.Equal(t, commentMetadata["key2"], "value2")
 
-	op2 := NewSetMetadataOp(rene, unix, hash2, map[string]string{
+	op2 := NewSetMetadataOp(rene, unix, id2, map[string]string{
 		"key2": "value",
 		"key3": "value3",
 	})
@@ -71,7 +71,7 @@ func TestSetMetadata(t *testing.T) {
 	// new key is set
 	assert.Equal(t, commentMetadata["key3"], "value3")
 
-	op3 := NewSetMetadataOp(rene, unix, hash1, map[string]string{
+	op3 := NewSetMetadataOp(rene, unix, id1, map[string]string{
 		"key":  "override",
 		"key2": "override",
 	})
@@ -107,8 +107,9 @@ func TestSetMetadataSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_metadata_test.go
+++ b/bug/op_set_metadata_test.go
@@ -21,16 +21,16 @@ func TestSetMetadata(t *testing.T) {
 	create.Apply(&snapshot)
 	snapshot.Operations = append(snapshot.Operations, create)
 
-	hash1, err := create.Hash()
-	require.NoError(t, err)
+	hash1 := create.ID()
+	require.True(t, IDIsValid(hash1))
 
 	comment := NewAddCommentOp(rene, unix, "comment", nil)
 	comment.SetMetadata("key2", "value2")
 	comment.Apply(&snapshot)
 	snapshot.Operations = append(snapshot.Operations, comment)
 
-	hash2, err := comment.Hash()
-	require.NoError(t, err)
+	hash2 := comment.ID()
+	require.True(t, IDIsValid(hash2))
 
 	op1 := NewSetMetadataOp(rene, unix, hash1, map[string]string{
 		"key":  "override",
@@ -106,6 +106,9 @@ func TestSetMetadataSerialize(t *testing.T) {
 	var after SetMetadataOperation
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
+
+	// enforce creating the ID
+	before.ID()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_status.go
+++ b/bug/op_set_status.go
@@ -3,10 +3,10 @@ package bug
 import (
 	"encoding/json"
 
-	"github.com/MichaelMure/git-bug/identity"
-	"github.com/MichaelMure/git-bug/util/git"
-	"github.com/MichaelMure/git-bug/util/timestamp"
 	"github.com/pkg/errors"
+
+	"github.com/MichaelMure/git-bug/identity"
+	"github.com/MichaelMure/git-bug/util/timestamp"
 )
 
 var _ Operation = &SetStatusOperation{}
@@ -21,23 +21,16 @@ func (op *SetStatusOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *SetStatusOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *SetStatusOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *SetStatusOperation) Apply(snapshot *Snapshot) {
 	snapshot.Status = op.Status
 	snapshot.addActor(op.Author)
 
-	hash, err := op.Hash()
-	if err != nil {
-		// Should never error unless a programming error happened
-		// (covered in OpBase.Validate())
-		panic(err)
-	}
-
 	item := &SetStatusTimelineItem{
-		hash:     hash,
+		id:       op.ID(),
 		Author:   op.Author,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Status:   op.Status,
@@ -114,14 +107,14 @@ func NewSetStatusOp(author identity.Interface, unixTime int64, status Status) *S
 }
 
 type SetStatusTimelineItem struct {
-	hash     git.Hash
+	id       string
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Status   Status
 }
 
-func (s SetStatusTimelineItem) Hash() git.Hash {
-	return s.hash
+func (s SetStatusTimelineItem) ID() string {
+	return s.id
 }
 
 // Sign post method for gqlgen

--- a/bug/op_set_status.go
+++ b/bug/op_set_status.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/timestamp"
 )
@@ -14,14 +15,14 @@ var _ Operation = &SetStatusOperation{}
 // SetStatusOperation will change the status of a bug
 type SetStatusOperation struct {
 	OpBase
-	Status Status
+	Status Status `json:"status"`
 }
 
 func (op *SetStatusOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *SetStatusOperation) ID() string {
+func (op *SetStatusOperation) Id() entity.Id {
 	return idOperation(op)
 }
 
@@ -30,7 +31,7 @@ func (op *SetStatusOperation) Apply(snapshot *Snapshot) {
 	snapshot.addActor(op.Author)
 
 	item := &SetStatusTimelineItem{
-		id:       op.ID(),
+		id:       op.Id(),
 		Author:   op.Author,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Status:   op.Status,
@@ -51,27 +52,9 @@ func (op *SetStatusOperation) Validate() error {
 	return nil
 }
 
-// Workaround to avoid the inner OpBase.MarshalJSON overriding the outer op
-// MarshalJSON
-func (op *SetStatusOperation) MarshalJSON() ([]byte, error) {
-	base, err := json.Marshal(op.OpBase)
-	if err != nil {
-		return nil, err
-	}
-
-	// revert back to a flat map to be able to add our own fields
-	var data map[string]interface{}
-	if err := json.Unmarshal(base, &data); err != nil {
-		return nil, err
-	}
-
-	data["status"] = op.Status
-
-	return json.Marshal(data)
-}
-
-// Workaround to avoid the inner OpBase.MarshalJSON overriding the outer op
-// MarshalJSON
+// UnmarshalJSON is a two step JSON unmarshaling
+// This workaround is necessary to avoid the inner OpBase.MarshalJSON
+// overriding the outer op's MarshalJSON
 func (op *SetStatusOperation) UnmarshalJSON(data []byte) error {
 	// Unmarshal OpBase and the op separately
 
@@ -107,13 +90,13 @@ func NewSetStatusOp(author identity.Interface, unixTime int64, status Status) *S
 }
 
 type SetStatusTimelineItem struct {
-	id       string
+	id       entity.Id
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Status   Status
 }
 
-func (s SetStatusTimelineItem) ID() string {
+func (s SetStatusTimelineItem) Id() entity.Id {
 	return s.id
 }
 

--- a/bug/op_set_status_test.go
+++ b/bug/op_set_status_test.go
@@ -21,5 +21,8 @@ func TestSetStatusSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the ID
+	before.ID()
+
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_status_test.go
+++ b/bug/op_set_status_test.go
@@ -21,8 +21,9 @@ func TestSetStatusSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_title.go
+++ b/bug/op_set_title.go
@@ -8,7 +8,6 @@ import (
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/timestamp"
 
-	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -25,23 +24,16 @@ func (op *SetTitleOperation) base() *OpBase {
 	return &op.OpBase
 }
 
-func (op *SetTitleOperation) Hash() (git.Hash, error) {
-	return hashOperation(op)
+func (op *SetTitleOperation) ID() string {
+	return idOperation(op)
 }
 
 func (op *SetTitleOperation) Apply(snapshot *Snapshot) {
 	snapshot.Title = op.Title
 	snapshot.addActor(op.Author)
 
-	hash, err := op.Hash()
-	if err != nil {
-		// Should never error unless a programming error happened
-		// (covered in OpBase.Validate())
-		panic(err)
-	}
-
 	item := &SetTitleTimelineItem{
-		hash:     hash,
+		id:       op.ID(),
 		Author:   op.Author,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Title:    op.Title,
@@ -139,15 +131,15 @@ func NewSetTitleOp(author identity.Interface, unixTime int64, title string, was 
 }
 
 type SetTitleTimelineItem struct {
-	hash     git.Hash
+	id       string
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Title    string
 	Was      string
 }
 
-func (s SetTitleTimelineItem) Hash() git.Hash {
-	return s.hash
+func (s SetTitleTimelineItem) ID() string {
+	return s.id
 }
 
 // Sign post method for gqlgen

--- a/bug/op_set_title_test.go
+++ b/bug/op_set_title_test.go
@@ -21,5 +21,8 @@ func TestSetTitleSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the ID
+	before.ID()
+
 	assert.Equal(t, before, &after)
 }

--- a/bug/op_set_title_test.go
+++ b/bug/op_set_title_test.go
@@ -21,8 +21,9 @@ func TestSetTitleSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
-	// enforce creating the ID
-	before.ID()
+	// enforce creating the IDs
+	before.Id()
+	rene.Id()
 
 	assert.Equal(t, before, &after)
 }

--- a/bug/operation_pack.go
+++ b/bug/operation_pack.go
@@ -63,9 +63,6 @@ func (opp *OperationPack) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		// Compute the hash of the operation
-		op.base().hash = hashRaw(raw)
-
 		opp.Operations = append(opp.Operations, op)
 	}
 

--- a/bug/operation_pack_test.go
+++ b/bug/operation_pack_test.go
@@ -48,14 +48,16 @@ func TestOperationPackSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &opp2)
 	assert.NoError(t, err)
 
-	ensureID(t, opp)
+	ensureIDs(t, opp)
 
 	assert.Equal(t, opp, opp2)
 }
 
-func ensureID(t *testing.T, opp *OperationPack) {
+func ensureIDs(t *testing.T, opp *OperationPack) {
 	for _, op := range opp.Operations {
-		id := op.ID()
-		require.True(t, IDIsValid(id))
+		id := op.Id()
+		require.NoError(t, id.Validate())
+		id = op.GetAuthor().Id()
+		require.NoError(t, id.Validate())
 	}
 }

--- a/bug/operation_pack_test.go
+++ b/bug/operation_pack_test.go
@@ -48,14 +48,14 @@ func TestOperationPackSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &opp2)
 	assert.NoError(t, err)
 
-	ensureHash(t, opp)
+	ensureID(t, opp)
 
 	assert.Equal(t, opp, opp2)
 }
 
-func ensureHash(t *testing.T, opp *OperationPack) {
+func ensureID(t *testing.T, opp *OperationPack) {
 	for _, op := range opp.Operations {
-		_, err := op.Hash()
-		require.NoError(t, err)
+		id := op.ID()
+		require.True(t, IDIsValid(id))
 	}
 }

--- a/bug/operation_test.go
+++ b/bug/operation_test.go
@@ -79,7 +79,7 @@ func TestMetadata(t *testing.T) {
 	require.Equal(t, val, "value")
 }
 
-func TestHash(t *testing.T) {
+func TestID(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(t, repo)
 
@@ -94,27 +94,27 @@ func TestHash(t *testing.T) {
 		b, op, err := Create(rene, time.Now().Unix(), "title", "message")
 		require.Nil(t, err)
 
-		h1, err := op.Hash()
-		require.Nil(t, err)
+		id1 := op.ID()
+		require.True(t, IDIsValid(id1))
 
 		err = b.Commit(repo)
 		require.Nil(t, err)
 
 		op2 := b.FirstOp()
 
-		h2, err := op2.Hash()
-		require.Nil(t, err)
+		id2 := op2.ID()
+		require.True(t, IDIsValid(id2))
 
-		require.Equal(t, h1, h2)
+		require.Equal(t, id1, id2)
 
 		b2, err := ReadLocalBug(repo, b.id)
 		require.Nil(t, err)
 
 		op3 := b2.FirstOp()
 
-		h3, err := op3.Hash()
-		require.Nil(t, err)
+		id3 := op3.ID()
+		require.True(t, IDIsValid(id3))
 
-		require.Equal(t, h1, h3)
+		require.Equal(t, id1, id3)
 	}
 }

--- a/bug/operation_test.go
+++ b/bug/operation_test.go
@@ -94,26 +94,26 @@ func TestID(t *testing.T) {
 		b, op, err := Create(rene, time.Now().Unix(), "title", "message")
 		require.Nil(t, err)
 
-		id1 := op.ID()
-		require.True(t, IDIsValid(id1))
+		id1 := op.Id()
+		require.NoError(t, id1.Validate())
 
 		err = b.Commit(repo)
 		require.Nil(t, err)
 
 		op2 := b.FirstOp()
 
-		id2 := op2.ID()
-		require.True(t, IDIsValid(id2))
+		id2 := op2.Id()
+		require.NoError(t, id2.Validate())
 
 		require.Equal(t, id1, id2)
 
-		b2, err := ReadLocalBug(repo, b.id)
+		b2, err := ReadLocalBug(repo, b.Id())
 		require.Nil(t, err)
 
 		op3 := b2.FirstOp()
 
-		id3 := op3.ID()
-		require.True(t, IDIsValid(id3))
+		id3 := op3.Id()
+		require.NoError(t, id3.Validate())
 
 		require.Equal(t, id1, id3)
 	}

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/MichaelMure/git-bug/identity"
-	"github.com/MichaelMure/git-bug/util/git"
 )
 
 // Snapshot is a compiled form of the Bug data structure used for storage and merge
@@ -71,9 +70,9 @@ func (snap *Snapshot) SearchTimelineItem(ID string) (TimelineItem, error) {
 }
 
 // SearchComment will search for a comment matching the given hash
-func (snap *Snapshot) SearchComment(hash git.Hash) (*Comment, error) {
+func (snap *Snapshot) SearchComment(id string) (*Comment, error) {
 	for _, c := range snap.Comments {
-		if c.id == hash.String() {
+		if c.id == id {
 			return &c, nil
 		}
 	}

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -60,9 +60,9 @@ func (snap *Snapshot) GetCreateMetadata(key string) (string, bool) {
 }
 
 // SearchTimelineItem will search in the timeline for an item matching the given hash
-func (snap *Snapshot) SearchTimelineItem(hash git.Hash) (TimelineItem, error) {
+func (snap *Snapshot) SearchTimelineItem(ID string) (TimelineItem, error) {
 	for i := range snap.Timeline {
-		if snap.Timeline[i].Hash() == hash {
+		if snap.Timeline[i].ID() == ID {
 			return snap.Timeline[i], nil
 		}
 	}

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 )
 
 // Snapshot is a compiled form of the Bug data structure used for storage and merge
 type Snapshot struct {
-	id string
+	id entity.Id
 
 	Status       Status
 	Title        string
@@ -26,13 +27,8 @@ type Snapshot struct {
 }
 
 // Return the Bug identifier
-func (snap *Snapshot) Id() string {
+func (snap *Snapshot) Id() entity.Id {
 	return snap.id
-}
-
-// Return the Bug identifier truncated for human consumption
-func (snap *Snapshot) HumanId() string {
-	return FormatHumanID(snap.id)
 }
 
 // Return the last time a bug was modified
@@ -59,9 +55,9 @@ func (snap *Snapshot) GetCreateMetadata(key string) (string, bool) {
 }
 
 // SearchTimelineItem will search in the timeline for an item matching the given hash
-func (snap *Snapshot) SearchTimelineItem(ID string) (TimelineItem, error) {
+func (snap *Snapshot) SearchTimelineItem(id entity.Id) (TimelineItem, error) {
 	for i := range snap.Timeline {
-		if snap.Timeline[i].ID() == ID {
+		if snap.Timeline[i].Id() == id {
 			return snap.Timeline[i], nil
 		}
 	}
@@ -72,7 +68,7 @@ func (snap *Snapshot) SearchTimelineItem(ID string) (TimelineItem, error) {
 // SearchComment will search for a comment matching the given hash
 func (snap *Snapshot) SearchComment(id string) (*Comment, error) {
 	for _, c := range snap.Comments {
-		if c.id == id {
+		if c.id.String() == id {
 			return &c, nil
 		}
 	}
@@ -103,7 +99,7 @@ func (snap *Snapshot) addParticipant(participant identity.Interface) {
 }
 
 // HasParticipant return true if the id is a participant
-func (snap *Snapshot) HasParticipant(id string) bool {
+func (snap *Snapshot) HasParticipant(id entity.Id) bool {
 	for _, p := range snap.Participants {
 		if p.Id() == id {
 			return true
@@ -113,7 +109,7 @@ func (snap *Snapshot) HasParticipant(id string) bool {
 }
 
 // HasAnyParticipant return true if one of the ids is a participant
-func (snap *Snapshot) HasAnyParticipant(ids ...string) bool {
+func (snap *Snapshot) HasAnyParticipant(ids ...entity.Id) bool {
 	for _, id := range ids {
 		if snap.HasParticipant(id) {
 			return true
@@ -123,7 +119,7 @@ func (snap *Snapshot) HasAnyParticipant(ids ...string) bool {
 }
 
 // HasActor return true if the id is a actor
-func (snap *Snapshot) HasActor(id string) bool {
+func (snap *Snapshot) HasActor(id entity.Id) bool {
 	for _, p := range snap.Actors {
 		if p.Id() == id {
 			return true
@@ -133,7 +129,7 @@ func (snap *Snapshot) HasActor(id string) bool {
 }
 
 // HasAnyActor return true if one of the ids is a actor
-func (snap *Snapshot) HasAnyActor(ids ...string) bool {
+func (snap *Snapshot) HasAnyActor(ids ...entity.Id) bool {
 	for _, id := range ids {
 		if snap.HasActor(id) {
 			return true

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -66,9 +66,9 @@ func (snap *Snapshot) SearchTimelineItem(id entity.Id) (TimelineItem, error) {
 }
 
 // SearchComment will search for a comment matching the given hash
-func (snap *Snapshot) SearchComment(id string) (*Comment, error) {
+func (snap *Snapshot) SearchComment(id entity.Id) (*Comment, error) {
 	for _, c := range snap.Comments {
-		if c.id.String() == id {
+		if c.id == id {
 			return &c, nil
 		}
 	}

--- a/bug/timeline.go
+++ b/bug/timeline.go
@@ -9,8 +9,8 @@ import (
 )
 
 type TimelineItem interface {
-	// Hash return the hash of the item
-	Hash() git.Hash
+	// ID return the identifier of the item
+	ID() string
 }
 
 // CommentHistoryStep hold one version of a message in the history
@@ -25,7 +25,7 @@ type CommentHistoryStep struct {
 
 // CommentTimelineItem is a TimelineItem that holds a Comment and its edition history
 type CommentTimelineItem struct {
-	hash      git.Hash
+	id        string
 	Author    identity.Interface
 	Message   string
 	Files     []git.Hash
@@ -34,9 +34,9 @@ type CommentTimelineItem struct {
 	History   []CommentHistoryStep
 }
 
-func NewCommentTimelineItem(hash git.Hash, comment Comment) CommentTimelineItem {
+func NewCommentTimelineItem(ID string, comment Comment) CommentTimelineItem {
 	return CommentTimelineItem{
-		hash:      hash,
+		id:        ID,
 		Author:    comment.Author,
 		Message:   comment.Message,
 		Files:     comment.Files,
@@ -51,8 +51,8 @@ func NewCommentTimelineItem(hash git.Hash, comment Comment) CommentTimelineItem 
 	}
 }
 
-func (c *CommentTimelineItem) Hash() git.Hash {
-	return c.hash
+func (c *CommentTimelineItem) ID() string {
+	return c.id
 }
 
 // Append will append a new comment in the history and update the other values

--- a/bug/timeline.go
+++ b/bug/timeline.go
@@ -3,6 +3,7 @@ package bug
 import (
 	"strings"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/git-bug/util/timestamp"
@@ -10,7 +11,7 @@ import (
 
 type TimelineItem interface {
 	// ID return the identifier of the item
-	ID() string
+	Id() entity.Id
 }
 
 // CommentHistoryStep hold one version of a message in the history
@@ -25,7 +26,7 @@ type CommentHistoryStep struct {
 
 // CommentTimelineItem is a TimelineItem that holds a Comment and its edition history
 type CommentTimelineItem struct {
-	id        string
+	id        entity.Id
 	Author    identity.Interface
 	Message   string
 	Files     []git.Hash
@@ -34,7 +35,7 @@ type CommentTimelineItem struct {
 	History   []CommentHistoryStep
 }
 
-func NewCommentTimelineItem(ID string, comment Comment) CommentTimelineItem {
+func NewCommentTimelineItem(ID entity.Id, comment Comment) CommentTimelineItem {
 	return CommentTimelineItem{
 		id:        ID,
 		Author:    comment.Author,
@@ -51,7 +52,7 @@ func NewCommentTimelineItem(ID string, comment Comment) CommentTimelineItem {
 	}
 }
 
-func (c *CommentTimelineItem) ID() string {
+func (c *CommentTimelineItem) Id() entity.Id {
 	return c.id
 }
 

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -2,12 +2,14 @@ package cache
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/MichaelMure/git-bug/bug"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/util/git"
 )
+
+var ErrNoMatchingOp = fmt.Errorf("no matching operation found")
 
 // BugCache is a wrapper around a Bug. It provide multiple functions:
 //
@@ -29,45 +31,25 @@ func (c *BugCache) Snapshot() *bug.Snapshot {
 	return c.bug.Snapshot()
 }
 
-func (c *BugCache) Id() string {
+func (c *BugCache) Id() entity.Id {
 	return c.bug.Id()
-}
-
-func (c *BugCache) HumanId() string {
-	return c.bug.HumanId()
 }
 
 func (c *BugCache) notifyUpdated() error {
 	return c.repoCache.bugUpdated(c.bug.Id())
 }
 
-var ErrNoMatchingOp = fmt.Errorf("no matching operation found")
-
-type ErrMultipleMatchOp struct {
-	Matching []string
-}
-
-func (e ErrMultipleMatchOp) Error() string {
-	casted := make([]string, len(e.Matching))
-
-	for i := range e.Matching {
-		casted[i] = string(e.Matching[i])
-	}
-
-	return fmt.Sprintf("Multiple matching operation found:\n%s", strings.Join(casted, "\n"))
-}
-
 // ResolveOperationWithMetadata will find an operation that has the matching metadata
-func (c *BugCache) ResolveOperationWithMetadata(key string, value string) (string, error) {
+func (c *BugCache) ResolveOperationWithMetadata(key string, value string) (entity.Id, error) {
 	// preallocate but empty
-	matching := make([]string, 0, 5)
+	matching := make([]entity.Id, 0, 5)
 
 	it := bug.NewOperationIterator(c.bug)
 	for it.Next() {
 		op := it.Value()
 		opValue, ok := op.GetMetadata(key)
 		if ok && value == opValue {
-			matching = append(matching, op.ID())
+			matching = append(matching, op.Id())
 		}
 	}
 
@@ -76,7 +58,7 @@ func (c *BugCache) ResolveOperationWithMetadata(key string, value string) (strin
 	}
 
 	if len(matching) > 1 {
-		return "", ErrMultipleMatchOp{Matching: matching}
+		return "", bug.NewErrMultipleMatchOp(matching)
 	}
 
 	return matching[0], nil
@@ -228,7 +210,7 @@ func (c *BugCache) SetTitleRaw(author *IdentityCache, unixTime int64, title stri
 	return op, c.notifyUpdated()
 }
 
-func (c *BugCache) EditComment(target string, message string) (*bug.EditCommentOperation, error) {
+func (c *BugCache) EditComment(target entity.Id, message string) (*bug.EditCommentOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
@@ -237,7 +219,7 @@ func (c *BugCache) EditComment(target string, message string) (*bug.EditCommentO
 	return c.EditCommentRaw(author, time.Now().Unix(), target, message, nil)
 }
 
-func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target string, message string, metadata map[string]string) (*bug.EditCommentOperation, error) {
+func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target entity.Id, message string, metadata map[string]string) (*bug.EditCommentOperation, error) {
 	op, err := bug.EditComment(c.bug, author.Identity, unixTime, target, message)
 	if err != nil {
 		return nil, err
@@ -250,7 +232,7 @@ func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target 
 	return op, c.notifyUpdated()
 }
 
-func (c *BugCache) SetMetadata(target string, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
+func (c *BugCache) SetMetadata(target entity.Id, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
@@ -259,7 +241,7 @@ func (c *BugCache) SetMetadata(target string, newMetadata map[string]string) (*b
 	return c.SetMetadataRaw(author, time.Now().Unix(), target, newMetadata)
 }
 
-func (c *BugCache) SetMetadataRaw(author *IdentityCache, unixTime int64, target string, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
+func (c *BugCache) SetMetadataRaw(author *IdentityCache, unixTime int64, target entity.Id, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
 	op, err := bug.SetMetadata(c.bug, author.Identity, unixTime, target, newMetadata)
 	if err != nil {
 		return nil, err

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -44,7 +44,7 @@ func (c *BugCache) notifyUpdated() error {
 var ErrNoMatchingOp = fmt.Errorf("no matching operation found")
 
 type ErrMultipleMatchOp struct {
-	Matching []git.Hash
+	Matching []string
 }
 
 func (e ErrMultipleMatchOp) Error() string {
@@ -58,20 +58,16 @@ func (e ErrMultipleMatchOp) Error() string {
 }
 
 // ResolveOperationWithMetadata will find an operation that has the matching metadata
-func (c *BugCache) ResolveOperationWithMetadata(key string, value string) (git.Hash, error) {
+func (c *BugCache) ResolveOperationWithMetadata(key string, value string) (string, error) {
 	// preallocate but empty
-	matching := make([]git.Hash, 0, 5)
+	matching := make([]string, 0, 5)
 
 	it := bug.NewOperationIterator(c.bug)
 	for it.Next() {
 		op := it.Value()
 		opValue, ok := op.GetMetadata(key)
 		if ok && value == opValue {
-			h, err := op.Hash()
-			if err != nil {
-				return "", err
-			}
-			matching = append(matching, h)
+			matching = append(matching, op.ID())
 		}
 	}
 
@@ -232,7 +228,7 @@ func (c *BugCache) SetTitleRaw(author *IdentityCache, unixTime int64, title stri
 	return op, c.notifyUpdated()
 }
 
-func (c *BugCache) EditComment(target git.Hash, message string) (*bug.EditCommentOperation, error) {
+func (c *BugCache) EditComment(target string, message string) (*bug.EditCommentOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
@@ -241,7 +237,7 @@ func (c *BugCache) EditComment(target git.Hash, message string) (*bug.EditCommen
 	return c.EditCommentRaw(author, time.Now().Unix(), target, message, nil)
 }
 
-func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target git.Hash, message string, metadata map[string]string) (*bug.EditCommentOperation, error) {
+func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target string, message string, metadata map[string]string) (*bug.EditCommentOperation, error) {
 	op, err := bug.EditComment(c.bug, author.Identity, unixTime, target, message)
 	if err != nil {
 		return nil, err
@@ -254,7 +250,7 @@ func (c *BugCache) EditCommentRaw(author *IdentityCache, unixTime int64, target 
 	return op, c.notifyUpdated()
 }
 
-func (c *BugCache) SetMetadata(target git.Hash, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
+func (c *BugCache) SetMetadata(target string, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
@@ -263,7 +259,7 @@ func (c *BugCache) SetMetadata(target git.Hash, newMetadata map[string]string) (
 	return c.SetMetadataRaw(author, time.Now().Unix(), target, newMetadata)
 }
 
-func (c *BugCache) SetMetadataRaw(author *IdentityCache, unixTime int64, target git.Hash, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
+func (c *BugCache) SetMetadataRaw(author *IdentityCache, unixTime int64, target string, newMetadata map[string]string) (*bug.SetMetadataOperation, error) {
 	op, err := bug.SetMetadata(c.bug, author.Identity, unixTime, target, newMetadata)
 	if err != nil {
 		return nil, err

--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -18,7 +18,7 @@ func init() {
 // BugExcerpt hold a subset of the bug values to be able to sort and filter bugs
 // efficiently without having to read and compile each raw bugs.
 type BugExcerpt struct {
-	Id entity.ID
+	Id entity.Id
 
 	CreateLamportTime lamport.Time
 	EditLamportTime   lamport.Time
@@ -29,14 +29,14 @@ type BugExcerpt struct {
 	Labels       []bug.Label
 	Title        string
 	LenComments  int
-	Actors       []entity.ID
-	Participants []entity.ID
+	Actors       []entity.Id
+	Participants []entity.Id
 
 	// If author is identity.Bare, LegacyAuthor is set
 	// If author is identity.Identity, AuthorId is set and data is deported
 	// in a IdentityExcerpt
 	LegacyAuthor LegacyAuthorExcerpt
-	AuthorId     string
+	AuthorId     entity.Id
 
 	CreateMetadata map[string]string
 }
@@ -61,12 +61,12 @@ func (l LegacyAuthorExcerpt) DisplayName() string {
 }
 
 func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
-	participantsIds := make([]string, len(snap.Participants))
+	participantsIds := make([]entity.Id, len(snap.Participants))
 	for i, participant := range snap.Participants {
 		participantsIds[i] = participant.Id()
 	}
 
-	actorsIds := make([]string, len(snap.Actors))
+	actorsIds := make([]entity.Id, len(snap.Actors))
 	for i, actor := range snap.Actors {
 		actorsIds[i] = actor.Id()
 	}
@@ -99,10 +99,6 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 	}
 
 	return e
-}
-
-func (b *BugExcerpt) HumanId() string {
-	return bug.FormatHumanID(b.Id)
 }
 
 /*

--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/bug"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/lamport"
 )
@@ -17,7 +18,7 @@ func init() {
 // BugExcerpt hold a subset of the bug values to be able to sort and filter bugs
 // efficiently without having to read and compile each raw bugs.
 type BugExcerpt struct {
-	Id string
+	Id entity.ID
 
 	CreateLamportTime lamport.Time
 	EditLamportTime   lamport.Time
@@ -28,8 +29,8 @@ type BugExcerpt struct {
 	Labels       []bug.Label
 	Title        string
 	LenComments  int
-	Actors       []string
-	Participants []string
+	Actors       []entity.ID
+	Participants []entity.ID
 
 	// If author is identity.Bare, LegacyAuthor is set
 	// If author is identity.Identity, AuthorId is set and data is deported

--- a/cache/identity_excerpt.go
+++ b/cache/identity_excerpt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/identity"
 )
 
@@ -17,7 +18,7 @@ func init() {
 // filter identities efficiently without having to read and compile each raw
 // identity.
 type IdentityExcerpt struct {
-	Id string
+	Id entity.Id
 
 	Name              string
 	Login             string
@@ -31,10 +32,6 @@ func NewIdentityExcerpt(i *identity.Identity) *IdentityExcerpt {
 		Login:             i.Login(),
 		ImmutableMetadata: i.ImmutableMetadata(),
 	}
-}
-
-func (i *IdentityExcerpt) HumanId() string {
-	return identity.FormatHumanID(i.Id)
 }
 
 // DisplayName return a non-empty string to display, representing the
@@ -54,7 +51,7 @@ func (i *IdentityExcerpt) DisplayName() string {
 
 // Match matches a query with the identity name, login and ID prefixes
 func (i *IdentityExcerpt) Match(query string) bool {
-	return strings.HasPrefix(i.Id, query) ||
+	return i.Id.HasPrefix(query) ||
 		strings.Contains(strings.ToLower(i.Name), query) ||
 		strings.Contains(strings.ToLower(i.Login), query)
 }

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -57,14 +57,14 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.ResolveIdentityExcerpt(iden1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveIdentityPrefix(iden1.Id()[:10])
+	_, err = cache.ResolveIdentityPrefix(iden1.Id().String()[:10])
 	require.NoError(t, err)
 
 	_, err = cache.ResolveBug(bug1.Id())
 	require.NoError(t, err)
 	_, err = cache.ResolveBugExcerpt(bug1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveBugPrefix(bug1.Id()[:10])
+	_, err = cache.ResolveBugPrefix(bug1.Id().String()[:10])
 	require.NoError(t, err)
 
 	// Querying
@@ -91,14 +91,14 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.ResolveIdentityExcerpt(iden1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveIdentityPrefix(iden1.Id()[:10])
+	_, err = cache.ResolveIdentityPrefix(iden1.Id().String()[:10])
 	require.NoError(t, err)
 
 	_, err = cache.ResolveBug(bug1.Id())
 	require.NoError(t, err)
 	_, err = cache.ResolveBugExcerpt(bug1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveBugPrefix(bug1.Id()[:10])
+	_, err = cache.ResolveBugPrefix(bug1.Id().String()[:10])
 	require.NoError(t, err)
 }
 

--- a/commands/add.go
+++ b/commands/add.go
@@ -49,7 +49,7 @@ func runAddBug(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("%s created\n", b.HumanId())
+	fmt.Printf("%s created\n", b.Id().Human())
 
 	return nil
 }

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -39,7 +39,7 @@ func commentsTextOutput(comments []bug.Comment) {
 		}
 
 		fmt.Printf("Author: %s\n", colors.Magenta(comment.Author.DisplayName()))
-		fmt.Printf("Id: %s\n", colors.Cyan(comment.HumanId()))
+		fmt.Printf("Id: %s\n", colors.Cyan(comment.Id().Human()))
 		fmt.Printf("Date: %s\n\n", comment.FormatTime())
 		fmt.Println(text.LeftPad(comment.Message, 4))
 	}

--- a/commands/ls-id.go
+++ b/commands/ls-id.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/util/interrupt"
-	"github.com/spf13/cobra"
 )
 
 func runLsID(cmd *cobra.Command, args []string) error {
@@ -24,7 +24,7 @@ func runLsID(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, id := range backend.AllBugsIds() {
-		if prefix == "" || strings.HasPrefix(id, prefix) {
+		if prefix == "" || id.HasPrefix(prefix) {
 			fmt.Println(id)
 		}
 	}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -70,7 +70,7 @@ func runLsBug(cmd *cobra.Command, args []string) error {
 		authorFmt := text.LeftPadMaxLine(name, 15, 0)
 
 		fmt.Printf("%s %s\t%s\t%s\tC:%d L:%d\n",
-			colors.Cyan(b.HumanId()),
+			colors.Cyan(b.Id.Human()),
 			colors.Yellow(b.Status),
 			titleFmt,
 			colors.Magenta(authorFmt),

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/MichaelMure/git-bug/bug"
+	"github.com/spf13/cobra"
+
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/util/interrupt"
-	"github.com/spf13/cobra"
 )
 
 func runPull(cmd *cobra.Command, args []string) error {
@@ -45,7 +45,7 @@ func runPull(cmd *cobra.Command, args []string) error {
 		}
 
 		if result.Status != entity.MergeStatusNothing {
-			fmt.Printf("%s: %s\n", bug.FormatHumanID(result.Id), result)
+			fmt.Printf("%s: %s\n", result.Id.Human(), result)
 		}
 	}
 

--- a/commands/select.go
+++ b/commands/select.go
@@ -34,7 +34,7 @@ func runSelect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("selected bug %s: %s\n", b.HumanId(), b.Snapshot().Title)
+	fmt.Printf("selected bug %s: %s\n", b.Id().Human(), b.Snapshot().Title)
 
 	return nil
 }

--- a/commands/select/select.go
+++ b/commands/select/select.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"path"
 
+	"github.com/pkg/errors"
+
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/repository"
-	"github.com/MichaelMure/git-bug/util/git"
-	"github.com/pkg/errors"
 )
 
 const selectFile = "select"
@@ -112,8 +112,8 @@ func selected(repo *cache.RepoCache) (*cache.BugCache, error) {
 		return nil, fmt.Errorf("the select file should be < 100 bytes")
 	}
 
-	h := git.Hash(buf)
-	if !h.IsValid() {
+	id := string(buf)
+	if !bug.IDIsValid(id) {
 		err = os.Remove(selectPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while removing invalid select file")
@@ -122,7 +122,7 @@ func selected(repo *cache.RepoCache) (*cache.BugCache, error) {
 		return nil, fmt.Errorf("select file in invalid, removing it")
 	}
 
-	b, err := repo.ResolveBug(string(h))
+	b, err := repo.ResolveBug(id)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/select/select.go
+++ b/commands/select/select.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 )
 
@@ -69,7 +70,7 @@ func ResolveBug(repo *cache.RepoCache, args []string) (*cache.BugCache, []string
 }
 
 // Select will select a bug for future use
-func Select(repo *cache.RepoCache, id string) error {
+func Select(repo *cache.RepoCache, id entity.Id) error {
 	selectPath := selectFilePath(repo)
 
 	f, err := os.OpenFile(selectPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
@@ -77,7 +78,7 @@ func Select(repo *cache.RepoCache, id string) error {
 		return err
 	}
 
-	_, err = f.WriteString(id)
+	_, err = f.WriteString(id.String())
 	if err != nil {
 		return err
 	}
@@ -112,8 +113,8 @@ func selected(repo *cache.RepoCache) (*cache.BugCache, error) {
 		return nil, fmt.Errorf("the select file should be < 100 bytes")
 	}
 
-	id := string(buf)
-	if !bug.IDIsValid(id) {
+	id := entity.Id(buf)
+	if err := id.Validate(); err != nil {
 		err = os.Remove(selectPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while removing invalid select file")

--- a/commands/select/select_test.go
+++ b/commands/select/select_test.go
@@ -52,12 +52,12 @@ func TestSelect(t *testing.T) {
 	require.Equal(t, b1.Id(), b3.Id())
 
 	// override selection with same id
-	b4, _, err := ResolveBug(repoCache, []string{b1.Id()})
+	b4, _, err := ResolveBug(repoCache, []string{b1.Id().String()})
 	require.NoError(t, err)
 	require.Equal(t, b1.Id(), b4.Id())
 
 	// override selection with a prefix
-	b5, _, err := ResolveBug(repoCache, []string{b1.HumanId()})
+	b5, _, err := ResolveBug(repoCache, []string{b1.Id().Human()})
 	require.NoError(t, err)
 	require.Equal(t, b1.Id(), b5.Id())
 
@@ -67,7 +67,7 @@ func TestSelect(t *testing.T) {
 	require.Equal(t, b1.Id(), b6.Id())
 
 	// override with a different id
-	b7, _, err := ResolveBug(repoCache, []string{b2.Id()})
+	b7, _, err := ResolveBug(repoCache, []string{b2.Id().String()})
 	require.NoError(t, err)
 	require.Equal(t, b2.Id(), b7.Id())
 

--- a/commands/show.go
+++ b/commands/show.go
@@ -46,7 +46,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		case "createTime":
 			fmt.Printf("%s\n", firstComment.FormatTime())
 		case "humanId":
-			fmt.Printf("%s\n", snapshot.HumanId())
+			fmt.Printf("%s\n", snapshot.Id().Human())
 		case "id":
 			fmt.Printf("%s\n", snapshot.Id())
 		case "labels":
@@ -62,7 +62,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%s\n", p.DisplayName())
 			}
 		case "shortId":
-			fmt.Printf("%s\n", snapshot.HumanId())
+			fmt.Printf("%s\n", snapshot.Id().Human())
 		case "status":
 			fmt.Printf("%s\n", snapshot.Status)
 		case "title":
@@ -77,7 +77,7 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 	// Header
 	fmt.Printf("[%s] %s %s\n\n",
 		colors.Yellow(snapshot.Status),
-		colors.Cyan(snapshot.HumanId()),
+		colors.Cyan(snapshot.Id().Human()),
 		snapshot.Title,
 	)
 

--- a/commands/user.go
+++ b/commands/user.go
@@ -41,7 +41,7 @@ func runUser(cmd *cobra.Command, args []string) error {
 		case "email":
 			fmt.Printf("%s\n", id.Email())
 		case "humanId":
-			fmt.Printf("%s\n", id.HumanId())
+			fmt.Printf("%s\n", id.Id().Human())
 		case "id":
 			fmt.Printf("%s\n", id.Id())
 		case "lastModification":

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -24,7 +24,7 @@ func runUserLs(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Printf("%s %s\n",
-			colors.Cyan(i.HumanId()),
+			colors.Cyan(i.Id.Human()),
 			i.DisplayName(),
 		)
 	}

--- a/entity/err.go
+++ b/entity/err.go
@@ -1,0 +1,1 @@
+package entity

--- a/entity/err.go
+++ b/entity/err.go
@@ -1,1 +1,27 @@
 package entity
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ErrMultipleMatch struct {
+	entityType string
+	Matching   []Id
+}
+
+func NewErrMultipleMatch(entityType string, matching []Id) *ErrMultipleMatch {
+	return &ErrMultipleMatch{entityType: entityType, Matching: matching}
+}
+
+func (e ErrMultipleMatch) Error() string {
+	matching := make([]string, len(e.Matching))
+
+	for i, match := range e.Matching {
+		matching[i] = match.String()
+	}
+
+	return fmt.Sprintf("Multiple matching %s found:\n%s",
+		e.entityType,
+		strings.Join(matching, "\n"))
+}

--- a/entity/id.go
+++ b/entity/id.go
@@ -17,10 +17,12 @@ const UnsetId = Id("unset")
 // Id is an identifier for an entity or part of an entity
 type Id string
 
+// String return the identifier as a string
 func (i Id) String() string {
 	return string(i)
 }
 
+// Human return the identifier, shortened for human consumption
 func (i Id) Human() string {
 	format := fmt.Sprintf("%%.%ds", humanIdLength)
 	return fmt.Sprintf(format, i)

--- a/entity/id.go
+++ b/entity/id.go
@@ -1,0 +1,65 @@
+package entity
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const IdLengthSHA1 = 40
+const IdLengthSHA256 = 64
+const humanIdLength = 7
+
+const UnsetId = Id("unset")
+
+// Id is an identifier for an entity or part of an entity
+type Id string
+
+func (i Id) String() string {
+	return string(i)
+}
+
+func (i Id) Human() string {
+	format := fmt.Sprintf("%%.%ds", humanIdLength)
+	return fmt.Sprintf(format, i)
+}
+
+func (i Id) HasPrefix(prefix string) bool {
+	return strings.HasPrefix(string(i), prefix)
+}
+
+// UnmarshalGQL implement the Unmarshaler interface for gqlgen
+func (i *Id) UnmarshalGQL(v interface{}) error {
+	_, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("IDs must be strings")
+	}
+
+	*i = v.(Id)
+
+	if err := i.Validate(); err != nil {
+		return errors.Wrap(err, "invalid ID")
+	}
+
+	return nil
+}
+
+// MarshalGQL implement the Marshaler interface for gqlgen
+func (i Id) MarshalGQL(w io.Writer) {
+	_, _ = w.Write([]byte(`"` + i.String() + `"`))
+}
+
+// IsValid tell if the Id is valid
+func (i Id) Validate() error {
+	if len(i) != IdLengthSHA1 && len(i) != IdLengthSHA256 {
+		return fmt.Errorf("invalid length")
+	}
+	for _, r := range i {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return fmt.Errorf("invalid character")
+		}
+	}
+	return nil
+}

--- a/entity/interface.go
+++ b/entity/interface.go
@@ -2,7 +2,5 @@ package entity
 
 type Interface interface {
 	// Id return the Entity identifier
-	Id() string
-	// HumanId return the Entity identifier truncated for human consumption
-	HumanId() string
+	Id() Id
 }

--- a/entity/merge.go
+++ b/entity/merge.go
@@ -1,6 +1,8 @@
 package entity
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // MergeStatus represent the result of a merge operation of an entity
 type MergeStatus int
@@ -17,7 +19,7 @@ type MergeResult struct {
 	// Err is set when a terminal error occur in the process
 	Err error
 
-	Id     string
+	Id     Id
 	Status MergeStatus
 
 	// Only set for invalid status
@@ -42,14 +44,14 @@ func (mr MergeResult) String() string {
 	}
 }
 
-func NewMergeError(err error, id string) MergeResult {
+func NewMergeError(err error, id Id) MergeResult {
 	return MergeResult{
 		Err: err,
 		Id:  id,
 	}
 }
 
-func NewMergeStatus(status MergeStatus, id string, entity Interface) MergeResult {
+func NewMergeStatus(status MergeStatus, id Id, entity Interface) MergeResult {
 	return MergeResult{
 		Id:     id,
 		Status: status,
@@ -59,7 +61,7 @@ func NewMergeStatus(status MergeStatus, id string, entity Interface) MergeResult
 	}
 }
 
-func NewMergeInvalidStatus(id string, reason string) MergeResult {
+func NewMergeInvalidStatus(id Id, reason string) MergeResult {
 	return MergeResult{
 		Id:     id,
 		Status: MergeStatusInvalid,

--- a/graphql/connections/connections.go
+++ b/graphql/connections/connections.go
@@ -1,5 +1,5 @@
-//go:generate genny -in=connection_template.go -out=gen_lazy_bug.go gen "Name=LazyBug NodeType=string EdgeType=LazyBugEdge ConnectionType=models.BugConnection"
-//go:generate genny -in=connection_template.go -out=gen_lazy_identity.go gen "Name=LazyIdentity NodeType=string EdgeType=LazyIdentityEdge ConnectionType=models.IdentityConnection"
+//go:generate genny -in=connection_template.go -out=gen_lazy_bug.go gen "Name=LazyBug NodeType=entity.Id EdgeType=LazyBugEdge ConnectionType=models.BugConnection"
+//go:generate genny -in=connection_template.go -out=gen_lazy_identity.go gen "Name=LazyIdentity NodeType=entity.Id EdgeType=LazyIdentityEdge ConnectionType=models.IdentityConnection"
 //go:generate genny -in=connection_template.go -out=gen_identity.go gen "Name=Identity NodeType=identity.Interface EdgeType=models.IdentityEdge ConnectionType=models.IdentityConnection"
 //go:generate genny -in=connection_template.go -out=gen_operation.go gen "Name=Operation NodeType=bug.Operation EdgeType=models.OperationEdge ConnectionType=models.OperationConnection"
 //go:generate genny -in=connection_template.go -out=gen_comment.go gen "Name=Comment NodeType=bug.Comment EdgeType=models.CommentEdge ConnectionType=models.CommentConnection"

--- a/graphql/connections/gen_lazy_bug.go
+++ b/graphql/connections/gen_lazy_bug.go
@@ -7,23 +7,24 @@ package connections
 import (
 	"fmt"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/graphql/models"
 )
 
-// StringEdgeMaker define a function that take a string and an offset and
+// EntityIdEdgeMaker define a function that take a entity.Id and an offset and
 // create an Edge.
-type LazyBugEdgeMaker func(value string, offset int) Edge
+type LazyBugEdgeMaker func(value entity.Id, offset int) Edge
 
 // LazyBugConMaker define a function that create a models.BugConnection
 type LazyBugConMaker func(
 	edges []*LazyBugEdge,
-	nodes []string,
+	nodes []entity.Id,
 	info *models.PageInfo,
 	totalCount int) (*models.BugConnection, error)
 
 // LazyBugCon will paginate a source according to the input of a relay connection
-func LazyBugCon(source []string, edgeMaker LazyBugEdgeMaker, conMaker LazyBugConMaker, input models.ConnectionInput) (*models.BugConnection, error) {
-	var nodes []string
+func LazyBugCon(source []entity.Id, edgeMaker LazyBugEdgeMaker, conMaker LazyBugConMaker, input models.ConnectionInput) (*models.BugConnection, error) {
+	var nodes []entity.Id
 	var edges []*LazyBugEdge
 	var cursors []string
 	var pageInfo = &models.PageInfo{}

--- a/graphql/connections/gen_lazy_identity.go
+++ b/graphql/connections/gen_lazy_identity.go
@@ -7,23 +7,24 @@ package connections
 import (
 	"fmt"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/graphql/models"
 )
 
-// StringEdgeMaker define a function that take a string and an offset and
+// EntityIdEdgeMaker define a function that take a entity.Id and an offset and
 // create an Edge.
-type LazyIdentityEdgeMaker func(value string, offset int) Edge
+type LazyIdentityEdgeMaker func(value entity.Id, offset int) Edge
 
 // LazyIdentityConMaker define a function that create a models.IdentityConnection
 type LazyIdentityConMaker func(
 	edges []*LazyIdentityEdge,
-	nodes []string,
+	nodes []entity.Id,
 	info *models.PageInfo,
 	totalCount int) (*models.IdentityConnection, error)
 
 // LazyIdentityCon will paginate a source according to the input of a relay connection
-func LazyIdentityCon(source []string, edgeMaker LazyIdentityEdgeMaker, conMaker LazyIdentityConMaker, input models.ConnectionInput) (*models.IdentityConnection, error) {
-	var nodes []string
+func LazyIdentityCon(source []entity.Id, edgeMaker LazyIdentityEdgeMaker, conMaker LazyIdentityConMaker, input models.ConnectionInput) (*models.IdentityConnection, error) {
+	var nodes []entity.Id
 	var edges []*LazyIdentityEdge
 	var cursors []string
 	var pageInfo = &models.PageInfo{}

--- a/graphql/connections/lazy_bug.go
+++ b/graphql/connections/lazy_bug.go
@@ -1,8 +1,10 @@
 package connections
 
+import "github.com/MichaelMure/git-bug/entity"
+
 // LazyBugEdge is a special relay edge used to implement a lazy loading connection
 type LazyBugEdge struct {
-	Id     string
+	Id     entity.Id
 	Cursor string
 }
 

--- a/graphql/connections/lazy_identity.go
+++ b/graphql/connections/lazy_identity.go
@@ -1,8 +1,10 @@
 package connections
 
+import "github.com/MichaelMure/git-bug/entity"
+
 // LazyIdentityEdge is a special relay edge used to implement a lazy loading connection
 type LazyIdentityEdge struct {
-	Id     string
+	Id     entity.Id
 	Cursor string
 }
 

--- a/graphql/graph/gen_graph.go
+++ b/graphql/graph/gen_graph.go
@@ -98,8 +98,8 @@ type ComplexityRoot struct {
 		Author       func(childComplexity int) int
 		Comments     func(childComplexity int, after *string, before *string, first *int, last *int) int
 		CreatedAt    func(childComplexity int) int
-		HumanId      func(childComplexity int) int
-		Id           func(childComplexity int) int
+		HumanID      func(childComplexity int) int
+		ID           func(childComplexity int) int
 		Labels       func(childComplexity int) int
 		LastEdit     func(childComplexity int) int
 		Operations   func(childComplexity int, after *string, before *string, first *int, last *int) int
@@ -358,13 +358,19 @@ type ComplexityRoot struct {
 }
 
 type AddCommentOperationResolver interface {
+	ID(ctx context.Context, obj *bug.AddCommentOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.AddCommentOperation) (*time.Time, error)
 }
 type AddCommentTimelineItemResolver interface {
+	ID(ctx context.Context, obj *bug.AddCommentTimelineItem) (string, error)
+
 	CreatedAt(ctx context.Context, obj *bug.AddCommentTimelineItem) (*time.Time, error)
 	LastEdit(ctx context.Context, obj *bug.AddCommentTimelineItem) (*time.Time, error)
 }
 type BugResolver interface {
+	ID(ctx context.Context, obj *bug.Snapshot) (string, error)
+	HumanID(ctx context.Context, obj *bug.Snapshot) (string, error)
 	Status(ctx context.Context, obj *bug.Snapshot) (models.Status, error)
 
 	LastEdit(ctx context.Context, obj *bug.Snapshot) (*time.Time, error)
@@ -383,14 +389,21 @@ type CommentHistoryStepResolver interface {
 	Date(ctx context.Context, obj *bug.CommentHistoryStep) (*time.Time, error)
 }
 type CreateOperationResolver interface {
+	ID(ctx context.Context, obj *bug.CreateOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.CreateOperation) (*time.Time, error)
 }
 type CreateTimelineItemResolver interface {
+	ID(ctx context.Context, obj *bug.CreateTimelineItem) (string, error)
+
 	CreatedAt(ctx context.Context, obj *bug.CreateTimelineItem) (*time.Time, error)
 	LastEdit(ctx context.Context, obj *bug.CreateTimelineItem) (*time.Time, error)
 }
 type EditCommentOperationResolver interface {
+	ID(ctx context.Context, obj *bug.EditCommentOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.EditCommentOperation) (*time.Time, error)
+	Target(ctx context.Context, obj *bug.EditCommentOperation) (string, error)
 }
 type IdentityResolver interface {
 	ID(ctx context.Context, obj *identity.Interface) (string, error)
@@ -407,12 +420,16 @@ type LabelResolver interface {
 	Color(ctx context.Context, obj *bug.Label) (*color.RGBA, error)
 }
 type LabelChangeOperationResolver interface {
+	ID(ctx context.Context, obj *bug.LabelChangeOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.LabelChangeOperation) (*time.Time, error)
 }
 type LabelChangeResultResolver interface {
 	Status(ctx context.Context, obj *bug.LabelChangeResult) (models.LabelChangeStatus, error)
 }
 type LabelChangeTimelineItemResolver interface {
+	ID(ctx context.Context, obj *bug.LabelChangeTimelineItem) (string, error)
+
 	Date(ctx context.Context, obj *bug.LabelChangeTimelineItem) (*time.Time, error)
 }
 type MutationResolver interface {
@@ -438,17 +455,25 @@ type RepositoryResolver interface {
 	ValidLabels(ctx context.Context, obj *models.Repository) ([]bug.Label, error)
 }
 type SetStatusOperationResolver interface {
+	ID(ctx context.Context, obj *bug.SetStatusOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.SetStatusOperation) (*time.Time, error)
 	Status(ctx context.Context, obj *bug.SetStatusOperation) (models.Status, error)
 }
 type SetStatusTimelineItemResolver interface {
+	ID(ctx context.Context, obj *bug.SetStatusTimelineItem) (string, error)
+
 	Date(ctx context.Context, obj *bug.SetStatusTimelineItem) (*time.Time, error)
 	Status(ctx context.Context, obj *bug.SetStatusTimelineItem) (models.Status, error)
 }
 type SetTitleOperationResolver interface {
+	ID(ctx context.Context, obj *bug.SetTitleOperation) (string, error)
+
 	Date(ctx context.Context, obj *bug.SetTitleOperation) (*time.Time, error)
 }
 type SetTitleTimelineItemResolver interface {
+	ID(ctx context.Context, obj *bug.SetTitleTimelineItem) (string, error)
+
 	Date(ctx context.Context, obj *bug.SetTitleTimelineItem) (*time.Time, error)
 }
 
@@ -625,18 +650,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		return e.complexity.Bug.CreatedAt(childComplexity), true
 
 	case "Bug.humanId":
-		if e.complexity.Bug.HumanId == nil {
+		if e.complexity.Bug.HumanID == nil {
 			break
 		}
 
-		return e.complexity.Bug.HumanId(childComplexity), true
+		return e.complexity.Bug.HumanID(childComplexity), true
 
 	case "Bug.id":
-		if e.complexity.Bug.Id == nil {
+		if e.complexity.Bug.ID == nil {
 			break
 		}
 
-		return e.complexity.Bug.Id(childComplexity), true
+		return e.complexity.Bug.ID(childComplexity), true
 
 	case "Bug.labels":
 		if e.complexity.Bug.Labels == nil {
@@ -2918,7 +2943,7 @@ func (ec *executionContext) _AddCommentOperation_id(ctx context.Context, field g
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.AddCommentOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3211,7 +3236,7 @@ func (ec *executionContext) _AddCommentTimelineItem_id(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.AddCommentTimelineItem().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3544,7 +3569,7 @@ func (ec *executionContext) _Bug_id(ctx context.Context, field graphql.Collected
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Id(), nil
+		return ec.resolvers.Bug().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3581,7 +3606,7 @@ func (ec *executionContext) _Bug_humanId(ctx context.Context, field graphql.Coll
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.HumanId(), nil
+		return ec.resolvers.Bug().HumanID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5195,7 +5220,7 @@ func (ec *executionContext) _CreateOperation_id(ctx context.Context, field graph
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.CreateOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5417,7 +5442,7 @@ func (ec *executionContext) _CreateTimelineItem_id(ctx context.Context, field gr
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.CreateTimelineItem().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5750,7 +5775,7 @@ func (ec *executionContext) _EditCommentOperation_id(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.EditCommentOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5855,13 +5880,13 @@ func (ec *executionContext) _EditCommentOperation_target(ctx context.Context, fi
 		Object:   "EditCommentOperation",
 		Field:    field,
 		Args:     nil,
-		IsMethod: false,
+		IsMethod: true,
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Target, nil
+		return ec.resolvers.EditCommentOperation().Target(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6552,7 +6577,7 @@ func (ec *executionContext) _LabelChangeOperation_id(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.LabelChangeOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6811,7 +6836,7 @@ func (ec *executionContext) _LabelChangeTimelineItem_id(ctx context.Context, fie
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.LabelChangeTimelineItem().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8325,7 +8350,7 @@ func (ec *executionContext) _SetStatusOperation_id(ctx context.Context, field gr
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.SetStatusOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8473,7 +8498,7 @@ func (ec *executionContext) _SetStatusTimelineItem_id(ctx context.Context, field
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.SetStatusTimelineItem().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8621,7 +8646,7 @@ func (ec *executionContext) _SetTitleOperation_id(ctx context.Context, field gra
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.SetTitleOperation().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8914,7 +8939,7 @@ func (ec *executionContext) _SetTitleTimelineItem_id(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
+		return ec.resolvers.SetTitleTimelineItem().ID(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10838,10 +10863,19 @@ func (ec *executionContext) _AddCommentOperation(ctx context.Context, sel ast.Se
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AddCommentOperation")
 		case "id":
-			out.Values[i] = ec._AddCommentOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AddCommentOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._AddCommentOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -10928,10 +10962,19 @@ func (ec *executionContext) _AddCommentTimelineItem(ctx context.Context, sel ast
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AddCommentTimelineItem")
 		case "id":
-			out.Values[i] = ec._AddCommentTimelineItem_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AddCommentTimelineItem_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._AddCommentTimelineItem_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11013,15 +11056,33 @@ func (ec *executionContext) _Bug(ctx context.Context, sel ast.SelectionSet, obj 
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Bug")
 		case "id":
-			out.Values[i] = ec._Bug_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Bug_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "humanId":
-			out.Values[i] = ec._Bug_humanId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Bug_humanId(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "status":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -11584,10 +11645,19 @@ func (ec *executionContext) _CreateOperation(ctx context.Context, sel ast.Select
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateOperation")
 		case "id":
-			out.Values[i] = ec._CreateOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CreateOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._CreateOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11645,10 +11715,19 @@ func (ec *executionContext) _CreateTimelineItem(ctx context.Context, sel ast.Sel
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateTimelineItem")
 		case "id":
-			out.Values[i] = ec._CreateTimelineItem_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CreateTimelineItem_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._CreateTimelineItem_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11730,10 +11809,19 @@ func (ec *executionContext) _EditCommentOperation(ctx context.Context, sel ast.S
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("EditCommentOperation")
 		case "id":
-			out.Values[i] = ec._EditCommentOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._EditCommentOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._EditCommentOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11754,10 +11842,19 @@ func (ec *executionContext) _EditCommentOperation(ctx context.Context, sel ast.S
 				return res
 			})
 		case "target":
-			out.Values[i] = ec._EditCommentOperation_target(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._EditCommentOperation_target(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "message":
 			out.Values[i] = ec._EditCommentOperation_message(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12037,10 +12134,19 @@ func (ec *executionContext) _LabelChangeOperation(ctx context.Context, sel ast.S
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LabelChangeOperation")
 		case "id":
-			out.Values[i] = ec._LabelChangeOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._LabelChangeOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._LabelChangeOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12134,10 +12240,19 @@ func (ec *executionContext) _LabelChangeTimelineItem(ctx context.Context, sel as
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LabelChangeTimelineItem")
 		case "id":
-			out.Values[i] = ec._LabelChangeTimelineItem_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._LabelChangeTimelineItem_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._LabelChangeTimelineItem_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12589,10 +12704,19 @@ func (ec *executionContext) _SetStatusOperation(ctx context.Context, sel ast.Sel
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetStatusOperation")
 		case "id":
-			out.Values[i] = ec._SetStatusOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SetStatusOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._SetStatusOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12649,10 +12773,19 @@ func (ec *executionContext) _SetStatusTimelineItem(ctx context.Context, sel ast.
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetStatusTimelineItem")
 		case "id":
-			out.Values[i] = ec._SetStatusTimelineItem_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SetStatusTimelineItem_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._SetStatusTimelineItem_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12709,10 +12842,19 @@ func (ec *executionContext) _SetTitleOperation(ctx context.Context, sel ast.Sele
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetTitleOperation")
 		case "id":
-			out.Values[i] = ec._SetTitleOperation_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SetTitleOperation_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._SetTitleOperation_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -12799,10 +12941,19 @@ func (ec *executionContext) _SetTitleTimelineItem(ctx context.Context, sel ast.S
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetTitleTimelineItem")
 		case "id":
-			out.Values[i] = ec._SetTitleTimelineItem_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SetTitleTimelineItem_id(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "author":
 			out.Values[i] = ec._SetTitleTimelineItem_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/graph/gen_graph.go
+++ b/graphql/graph/gen_graph.go
@@ -71,7 +71,7 @@ type ComplexityRoot struct {
 		Author  func(childComplexity int) int
 		Date    func(childComplexity int) int
 		Files   func(childComplexity int) int
-		Hash    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Message func(childComplexity int) int
 	}
 
@@ -86,8 +86,8 @@ type ComplexityRoot struct {
 		CreatedAt      func(childComplexity int) int
 		Edited         func(childComplexity int) int
 		Files          func(childComplexity int) int
-		Hash           func(childComplexity int) int
 		History        func(childComplexity int) int
+		ID             func(childComplexity int) int
 		LastEdit       func(childComplexity int) int
 		Message        func(childComplexity int) int
 		MessageIsEmpty func(childComplexity int) int
@@ -177,7 +177,7 @@ type ComplexityRoot struct {
 		Author  func(childComplexity int) int
 		Date    func(childComplexity int) int
 		Files   func(childComplexity int) int
-		Hash    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Message func(childComplexity int) int
 		Title   func(childComplexity int) int
 	}
@@ -187,8 +187,8 @@ type ComplexityRoot struct {
 		CreatedAt      func(childComplexity int) int
 		Edited         func(childComplexity int) int
 		Files          func(childComplexity int) int
-		Hash           func(childComplexity int) int
 		History        func(childComplexity int) int
+		ID             func(childComplexity int) int
 		LastEdit       func(childComplexity int) int
 		Message        func(childComplexity int) int
 		MessageIsEmpty func(childComplexity int) int
@@ -198,7 +198,7 @@ type ComplexityRoot struct {
 		Author  func(childComplexity int) int
 		Date    func(childComplexity int) int
 		Files   func(childComplexity int) int
-		Hash    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Message func(childComplexity int) int
 		Target  func(childComplexity int) int
 	}
@@ -235,7 +235,7 @@ type ComplexityRoot struct {
 		Added   func(childComplexity int) int
 		Author  func(childComplexity int) int
 		Date    func(childComplexity int) int
-		Hash    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Removed func(childComplexity int) int
 	}
 
@@ -248,7 +248,7 @@ type ComplexityRoot struct {
 		Added   func(childComplexity int) int
 		Author  func(childComplexity int) int
 		Date    func(childComplexity int) int
-		Hash    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		Removed func(childComplexity int) int
 	}
 
@@ -311,21 +311,21 @@ type ComplexityRoot struct {
 	SetStatusOperation struct {
 		Author func(childComplexity int) int
 		Date   func(childComplexity int) int
-		Hash   func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Status func(childComplexity int) int
 	}
 
 	SetStatusTimelineItem struct {
 		Author func(childComplexity int) int
 		Date   func(childComplexity int) int
-		Hash   func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Status func(childComplexity int) int
 	}
 
 	SetTitleOperation struct {
 		Author func(childComplexity int) int
 		Date   func(childComplexity int) int
-		Hash   func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Title  func(childComplexity int) int
 		Was    func(childComplexity int) int
 	}
@@ -339,7 +339,7 @@ type ComplexityRoot struct {
 	SetTitleTimelineItem struct {
 		Author func(childComplexity int) int
 		Date   func(childComplexity int) int
-		Hash   func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Title  func(childComplexity int) int
 		Was    func(childComplexity int) int
 	}
@@ -488,12 +488,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AddCommentOperation.Files(childComplexity), true
 
-	case "AddCommentOperation.hash":
-		if e.complexity.AddCommentOperation.Hash == nil {
+	case "AddCommentOperation.id":
+		if e.complexity.AddCommentOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.AddCommentOperation.Hash(childComplexity), true
+		return e.complexity.AddCommentOperation.ID(childComplexity), true
 
 	case "AddCommentOperation.message":
 		if e.complexity.AddCommentOperation.Message == nil {
@@ -551,19 +551,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AddCommentTimelineItem.Files(childComplexity), true
 
-	case "AddCommentTimelineItem.hash":
-		if e.complexity.AddCommentTimelineItem.Hash == nil {
-			break
-		}
-
-		return e.complexity.AddCommentTimelineItem.Hash(childComplexity), true
-
 	case "AddCommentTimelineItem.history":
 		if e.complexity.AddCommentTimelineItem.History == nil {
 			break
 		}
 
 		return e.complexity.AddCommentTimelineItem.History(childComplexity), true
+
+	case "AddCommentTimelineItem.id":
+		if e.complexity.AddCommentTimelineItem.ID == nil {
+			break
+		}
+
+		return e.complexity.AddCommentTimelineItem.ID(childComplexity), true
 
 	case "AddCommentTimelineItem.lastEdit":
 		if e.complexity.AddCommentTimelineItem.LastEdit == nil {
@@ -940,12 +940,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CreateOperation.Files(childComplexity), true
 
-	case "CreateOperation.hash":
-		if e.complexity.CreateOperation.Hash == nil {
+	case "CreateOperation.id":
+		if e.complexity.CreateOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.CreateOperation.Hash(childComplexity), true
+		return e.complexity.CreateOperation.ID(childComplexity), true
 
 	case "CreateOperation.message":
 		if e.complexity.CreateOperation.Message == nil {
@@ -989,19 +989,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CreateTimelineItem.Files(childComplexity), true
 
-	case "CreateTimelineItem.hash":
-		if e.complexity.CreateTimelineItem.Hash == nil {
-			break
-		}
-
-		return e.complexity.CreateTimelineItem.Hash(childComplexity), true
-
 	case "CreateTimelineItem.history":
 		if e.complexity.CreateTimelineItem.History == nil {
 			break
 		}
 
 		return e.complexity.CreateTimelineItem.History(childComplexity), true
+
+	case "CreateTimelineItem.id":
+		if e.complexity.CreateTimelineItem.ID == nil {
+			break
+		}
+
+		return e.complexity.CreateTimelineItem.ID(childComplexity), true
 
 	case "CreateTimelineItem.lastEdit":
 		if e.complexity.CreateTimelineItem.LastEdit == nil {
@@ -1045,12 +1045,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EditCommentOperation.Files(childComplexity), true
 
-	case "EditCommentOperation.hash":
-		if e.complexity.EditCommentOperation.Hash == nil {
+	case "EditCommentOperation.id":
+		if e.complexity.EditCommentOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.EditCommentOperation.Hash(childComplexity), true
+		return e.complexity.EditCommentOperation.ID(childComplexity), true
 
 	case "EditCommentOperation.message":
 		if e.complexity.EditCommentOperation.Message == nil {
@@ -1199,12 +1199,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LabelChangeOperation.Date(childComplexity), true
 
-	case "LabelChangeOperation.hash":
-		if e.complexity.LabelChangeOperation.Hash == nil {
+	case "LabelChangeOperation.id":
+		if e.complexity.LabelChangeOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.LabelChangeOperation.Hash(childComplexity), true
+		return e.complexity.LabelChangeOperation.ID(childComplexity), true
 
 	case "LabelChangeOperation.removed":
 		if e.complexity.LabelChangeOperation.Removed == nil {
@@ -1248,12 +1248,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LabelChangeTimelineItem.Date(childComplexity), true
 
-	case "LabelChangeTimelineItem.hash":
-		if e.complexity.LabelChangeTimelineItem.Hash == nil {
+	case "LabelChangeTimelineItem.id":
+		if e.complexity.LabelChangeTimelineItem.ID == nil {
 			break
 		}
 
-		return e.complexity.LabelChangeTimelineItem.Hash(childComplexity), true
+		return e.complexity.LabelChangeTimelineItem.ID(childComplexity), true
 
 	case "LabelChangeTimelineItem.removed":
 		if e.complexity.LabelChangeTimelineItem.Removed == nil {
@@ -1565,12 +1565,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SetStatusOperation.Date(childComplexity), true
 
-	case "SetStatusOperation.hash":
-		if e.complexity.SetStatusOperation.Hash == nil {
+	case "SetStatusOperation.id":
+		if e.complexity.SetStatusOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.SetStatusOperation.Hash(childComplexity), true
+		return e.complexity.SetStatusOperation.ID(childComplexity), true
 
 	case "SetStatusOperation.status":
 		if e.complexity.SetStatusOperation.Status == nil {
@@ -1593,12 +1593,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SetStatusTimelineItem.Date(childComplexity), true
 
-	case "SetStatusTimelineItem.hash":
-		if e.complexity.SetStatusTimelineItem.Hash == nil {
+	case "SetStatusTimelineItem.id":
+		if e.complexity.SetStatusTimelineItem.ID == nil {
 			break
 		}
 
-		return e.complexity.SetStatusTimelineItem.Hash(childComplexity), true
+		return e.complexity.SetStatusTimelineItem.ID(childComplexity), true
 
 	case "SetStatusTimelineItem.status":
 		if e.complexity.SetStatusTimelineItem.Status == nil {
@@ -1621,12 +1621,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SetTitleOperation.Date(childComplexity), true
 
-	case "SetTitleOperation.hash":
-		if e.complexity.SetTitleOperation.Hash == nil {
+	case "SetTitleOperation.id":
+		if e.complexity.SetTitleOperation.ID == nil {
 			break
 		}
 
-		return e.complexity.SetTitleOperation.Hash(childComplexity), true
+		return e.complexity.SetTitleOperation.ID(childComplexity), true
 
 	case "SetTitleOperation.title":
 		if e.complexity.SetTitleOperation.Title == nil {
@@ -1677,12 +1677,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SetTitleTimelineItem.Date(childComplexity), true
 
-	case "SetTitleTimelineItem.hash":
-		if e.complexity.SetTitleTimelineItem.Hash == nil {
+	case "SetTitleTimelineItem.id":
+		if e.complexity.SetTitleTimelineItem.ID == nil {
 			break
 		}
 
-		return e.complexity.SetTitleTimelineItem.Hash(childComplexity), true
+		return e.complexity.SetTitleTimelineItem.ID(childComplexity), true
 
 	case "SetTitleTimelineItem.title":
 		if e.complexity.SetTitleTimelineItem.Title == nil {
@@ -2126,8 +2126,8 @@ type CommitAsNeededPayload {
 `},
 	&ast.Source{Name: "schema/operations.graphql", Input: `"""An operation applied to a bug."""
 interface Operation {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The operations author."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2153,8 +2153,8 @@ type OperationEdge {
 # Operations
 
 type CreateOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2166,8 +2166,8 @@ type CreateOperation implements Operation & Authored {
 }
 
 type SetTitleOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2178,8 +2178,8 @@ type SetTitleOperation implements Operation & Authored {
 }
 
 type AddCommentOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2190,21 +2190,21 @@ type AddCommentOperation implements Operation & Authored {
 }
 
 type EditCommentOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
     date: Time!
 
-    target: Hash!
+    target: String!
     message: String!
     files: [Hash!]!
 }
 
 type SetStatusOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2214,8 +2214,8 @@ type SetStatusOperation implements Operation & Authored {
 }
 
 type LabelChangeOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -2291,8 +2291,8 @@ type Mutation {
 `},
 	&ast.Source{Name: "schema/timeline.graphql", Input: `"""An item in the timeline of events"""
 interface TimelineItem {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
 }
 
 """CommentHistoryStep hold one version of a message in the history"""
@@ -2321,8 +2321,8 @@ type TimelineItemEdge {
 
 """CreateTimelineItem is a TimelineItem that represent the creation of a bug and its message edition history"""
 type CreateTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     message: String!
     messageIsEmpty: Boolean!
@@ -2335,8 +2335,8 @@ type CreateTimelineItem implements TimelineItem & Authored {
 
 """AddCommentTimelineItem is a TimelineItem that represent a Comment and its edition history"""
 type AddCommentTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     message: String!
     messageIsEmpty: Boolean!
@@ -2349,8 +2349,8 @@ type AddCommentTimelineItem implements TimelineItem & Authored {
 
 """LabelChangeTimelineItem is a TimelineItem that represent a change in the labels of a bug"""
 type LabelChangeTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     added: [Label!]!
@@ -2359,8 +2359,8 @@ type LabelChangeTimelineItem implements TimelineItem & Authored {
 
 """SetStatusTimelineItem is a TimelineItem that represent a change in the status of a bug"""
 type SetStatusTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     status: Status!
@@ -2368,8 +2368,8 @@ type SetStatusTimelineItem implements TimelineItem & Authored {
 
 """LabelChangeTimelineItem is a TimelineItem that represent a change in the title of a bug"""
 type SetTitleTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     title: String!
@@ -2899,7 +2899,7 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _AddCommentOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _AddCommentOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -2918,7 +2918,7 @@ func (ec *executionContext) _AddCommentOperation_hash(ctx context.Context, field
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2930,10 +2930,10 @@ func (ec *executionContext) _AddCommentOperation_hash(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AddCommentOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentOperation) (ret graphql.Marshaler) {
@@ -3192,7 +3192,7 @@ func (ec *executionContext) _AddCommentPayload_operation(ctx context.Context, fi
 	return ec.marshalNAddCommentOperation2ᚖgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋbugᚐAddCommentOperation(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _AddCommentTimelineItem_hash(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentTimelineItem) (ret graphql.Marshaler) {
+func (ec *executionContext) _AddCommentTimelineItem_id(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentTimelineItem) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -3211,7 +3211,7 @@ func (ec *executionContext) _AddCommentTimelineItem_hash(ctx context.Context, fi
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash(), nil
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3223,10 +3223,10 @@ func (ec *executionContext) _AddCommentTimelineItem_hash(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AddCommentTimelineItem_author(ctx context.Context, field graphql.CollectedField, obj *bug.AddCommentTimelineItem) (ret graphql.Marshaler) {
@@ -5176,7 +5176,7 @@ func (ec *executionContext) _CommitPayload_bug(ctx context.Context, field graphq
 	return ec.marshalNBug2ᚖgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋbugᚐSnapshot(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _CreateOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.CreateOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _CreateOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.CreateOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -5195,7 +5195,7 @@ func (ec *executionContext) _CreateOperation_hash(ctx context.Context, field gra
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5207,10 +5207,10 @@ func (ec *executionContext) _CreateOperation_hash(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CreateOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.CreateOperation) (ret graphql.Marshaler) {
@@ -5398,7 +5398,7 @@ func (ec *executionContext) _CreateOperation_files(ctx context.Context, field gr
 	return ec.marshalNHash2ᚕgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _CreateTimelineItem_hash(ctx context.Context, field graphql.CollectedField, obj *bug.CreateTimelineItem) (ret graphql.Marshaler) {
+func (ec *executionContext) _CreateTimelineItem_id(ctx context.Context, field graphql.CollectedField, obj *bug.CreateTimelineItem) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -5417,7 +5417,7 @@ func (ec *executionContext) _CreateTimelineItem_hash(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash(), nil
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5429,10 +5429,10 @@ func (ec *executionContext) _CreateTimelineItem_hash(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CreateTimelineItem_author(ctx context.Context, field graphql.CollectedField, obj *bug.CreateTimelineItem) (ret graphql.Marshaler) {
@@ -5731,7 +5731,7 @@ func (ec *executionContext) _CreateTimelineItem_history(ctx context.Context, fie
 	return ec.marshalNCommentHistoryStep2ᚕgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋbugᚐCommentHistoryStep(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _EditCommentOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.EditCommentOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _EditCommentOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.EditCommentOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -5750,7 +5750,7 @@ func (ec *executionContext) _EditCommentOperation_hash(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5762,10 +5762,10 @@ func (ec *executionContext) _EditCommentOperation_hash(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EditCommentOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.EditCommentOperation) (ret graphql.Marshaler) {
@@ -5873,10 +5873,10 @@ func (ec *executionContext) _EditCommentOperation_target(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EditCommentOperation_message(ctx context.Context, field graphql.CollectedField, obj *bug.EditCommentOperation) (ret graphql.Marshaler) {
@@ -6533,7 +6533,7 @@ func (ec *executionContext) _Label_color(ctx context.Context, field graphql.Coll
 	return ec.marshalNColor2ᚖimageᚋcolorᚐRGBA(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _LabelChangeOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _LabelChangeOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -6552,7 +6552,7 @@ func (ec *executionContext) _LabelChangeOperation_hash(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6564,10 +6564,10 @@ func (ec *executionContext) _LabelChangeOperation_hash(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _LabelChangeOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeOperation) (ret graphql.Marshaler) {
@@ -6792,7 +6792,7 @@ func (ec *executionContext) _LabelChangeResult_status(ctx context.Context, field
 	return ec.marshalNLabelChangeStatus2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋgraphqlᚋmodelsᚐLabelChangeStatus(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _LabelChangeTimelineItem_hash(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeTimelineItem) (ret graphql.Marshaler) {
+func (ec *executionContext) _LabelChangeTimelineItem_id(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeTimelineItem) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -6811,7 +6811,7 @@ func (ec *executionContext) _LabelChangeTimelineItem_hash(ctx context.Context, f
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash(), nil
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6823,10 +6823,10 @@ func (ec *executionContext) _LabelChangeTimelineItem_hash(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _LabelChangeTimelineItem_author(ctx context.Context, field graphql.CollectedField, obj *bug.LabelChangeTimelineItem) (ret graphql.Marshaler) {
@@ -8306,7 +8306,7 @@ func (ec *executionContext) _Repository_validLabels(ctx context.Context, field g
 	return ec.marshalNLabel2ᚕgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋbugᚐLabel(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _SetStatusOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _SetStatusOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -8325,7 +8325,7 @@ func (ec *executionContext) _SetStatusOperation_hash(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8337,10 +8337,10 @@ func (ec *executionContext) _SetStatusOperation_hash(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SetStatusOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusOperation) (ret graphql.Marshaler) {
@@ -8454,7 +8454,7 @@ func (ec *executionContext) _SetStatusOperation_status(ctx context.Context, fiel
 	return ec.marshalNStatus2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋgraphqlᚋmodelsᚐStatus(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _SetStatusTimelineItem_hash(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusTimelineItem) (ret graphql.Marshaler) {
+func (ec *executionContext) _SetStatusTimelineItem_id(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusTimelineItem) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -8473,7 +8473,7 @@ func (ec *executionContext) _SetStatusTimelineItem_hash(ctx context.Context, fie
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash(), nil
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8485,10 +8485,10 @@ func (ec *executionContext) _SetStatusTimelineItem_hash(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SetStatusTimelineItem_author(ctx context.Context, field graphql.CollectedField, obj *bug.SetStatusTimelineItem) (ret graphql.Marshaler) {
@@ -8602,7 +8602,7 @@ func (ec *executionContext) _SetStatusTimelineItem_status(ctx context.Context, f
 	return ec.marshalNStatus2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋgraphqlᚋmodelsᚐStatus(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _SetTitleOperation_hash(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleOperation) (ret graphql.Marshaler) {
+func (ec *executionContext) _SetTitleOperation_id(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleOperation) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -8621,7 +8621,7 @@ func (ec *executionContext) _SetTitleOperation_hash(ctx context.Context, field g
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash()
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8633,10 +8633,10 @@ func (ec *executionContext) _SetTitleOperation_hash(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SetTitleOperation_author(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleOperation) (ret graphql.Marshaler) {
@@ -8895,7 +8895,7 @@ func (ec *executionContext) _SetTitlePayload_operation(ctx context.Context, fiel
 	return ec.marshalNSetTitleOperation2ᚖgithubᚗcomᚋMichaelMureᚋgitᚑbugᚋbugᚐSetTitleOperation(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _SetTitleTimelineItem_hash(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleTimelineItem) (ret graphql.Marshaler) {
+func (ec *executionContext) _SetTitleTimelineItem_id(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleTimelineItem) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -8914,7 +8914,7 @@ func (ec *executionContext) _SetTitleTimelineItem_hash(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Hash(), nil
+		return obj.ID(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8926,10 +8926,10 @@ func (ec *executionContext) _SetTitleTimelineItem_hash(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(git.Hash)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNHash2githubᚗcomᚋMichaelMureᚋgitᚑbugᚋutilᚋgitᚐHash(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SetTitleTimelineItem_author(ctx context.Context, field graphql.CollectedField, obj *bug.SetTitleTimelineItem) (ret graphql.Marshaler) {
@@ -10837,8 +10837,8 @@ func (ec *executionContext) _AddCommentOperation(ctx context.Context, sel ast.Se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AddCommentOperation")
-		case "hash":
-			out.Values[i] = ec._AddCommentOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._AddCommentOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -10927,8 +10927,8 @@ func (ec *executionContext) _AddCommentTimelineItem(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AddCommentTimelineItem")
-		case "hash":
-			out.Values[i] = ec._AddCommentTimelineItem_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._AddCommentTimelineItem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -11583,8 +11583,8 @@ func (ec *executionContext) _CreateOperation(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateOperation")
-		case "hash":
-			out.Values[i] = ec._CreateOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._CreateOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -11644,8 +11644,8 @@ func (ec *executionContext) _CreateTimelineItem(ctx context.Context, sel ast.Sel
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CreateTimelineItem")
-		case "hash":
-			out.Values[i] = ec._CreateTimelineItem_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._CreateTimelineItem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -11729,8 +11729,8 @@ func (ec *executionContext) _EditCommentOperation(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("EditCommentOperation")
-		case "hash":
-			out.Values[i] = ec._EditCommentOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._EditCommentOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12036,8 +12036,8 @@ func (ec *executionContext) _LabelChangeOperation(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LabelChangeOperation")
-		case "hash":
-			out.Values[i] = ec._LabelChangeOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._LabelChangeOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12133,8 +12133,8 @@ func (ec *executionContext) _LabelChangeTimelineItem(ctx context.Context, sel as
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LabelChangeTimelineItem")
-		case "hash":
-			out.Values[i] = ec._LabelChangeTimelineItem_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._LabelChangeTimelineItem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12588,8 +12588,8 @@ func (ec *executionContext) _SetStatusOperation(ctx context.Context, sel ast.Sel
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetStatusOperation")
-		case "hash":
-			out.Values[i] = ec._SetStatusOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._SetStatusOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12648,8 +12648,8 @@ func (ec *executionContext) _SetStatusTimelineItem(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetStatusTimelineItem")
-		case "hash":
-			out.Values[i] = ec._SetStatusTimelineItem_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._SetStatusTimelineItem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12708,8 +12708,8 @@ func (ec *executionContext) _SetTitleOperation(ctx context.Context, sel ast.Sele
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetTitleOperation")
-		case "hash":
-			out.Values[i] = ec._SetTitleOperation_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._SetTitleOperation_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
@@ -12798,8 +12798,8 @@ func (ec *executionContext) _SetTitleTimelineItem(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SetTitleTimelineItem")
-		case "hash":
-			out.Values[i] = ec._SetTitleTimelineItem_hash(ctx, field, obj)
+		case "id":
+			out.Values[i] = ec._SetTitleTimelineItem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}

--- a/graphql/resolvers/bug.go
+++ b/graphql/resolvers/bug.go
@@ -15,6 +15,14 @@ var _ graph.BugResolver = &bugResolver{}
 
 type bugResolver struct{}
 
+func (bugResolver) ID(ctx context.Context, obj *bug.Snapshot) (string, error) {
+	return obj.Id().String(), nil
+}
+
+func (bugResolver) HumanID(ctx context.Context, obj *bug.Snapshot) (string, error) {
+	return obj.Id().Human(), nil
+}
+
 func (bugResolver) Status(ctx context.Context, obj *bug.Snapshot) (models.Status, error) {
 	return convertStatus(obj.Status)
 }

--- a/graphql/resolvers/identity.go
+++ b/graphql/resolvers/identity.go
@@ -12,11 +12,11 @@ var _ graph.IdentityResolver = &identityResolver{}
 type identityResolver struct{}
 
 func (identityResolver) ID(ctx context.Context, obj *identity.Interface) (string, error) {
-	return (*obj).Id(), nil
+	return (*obj).Id().String(), nil
 }
 
 func (identityResolver) HumanID(ctx context.Context, obj *identity.Interface) (string, error) {
-	return (*obj).HumanId(), nil
+	return (*obj).Id().Human(), nil
 }
 
 func (identityResolver) Name(ctx context.Context, obj *identity.Interface) (*string, error) {

--- a/graphql/resolvers/operations.go
+++ b/graphql/resolvers/operations.go
@@ -6,38 +6,73 @@ import (
 	"time"
 
 	"github.com/MichaelMure/git-bug/bug"
+	"github.com/MichaelMure/git-bug/graphql/graph"
 	"github.com/MichaelMure/git-bug/graphql/models"
 )
 
+var _ graph.CreateOperationResolver = createOperationResolver{}
+
 type createOperationResolver struct{}
+
+func (createOperationResolver) ID(ctx context.Context, obj *bug.CreateOperation) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (createOperationResolver) Date(ctx context.Context, obj *bug.CreateOperation) (*time.Time, error) {
 	t := obj.Time()
 	return &t, nil
 }
 
+var _ graph.AddCommentOperationResolver = addCommentOperationResolver{}
+
 type addCommentOperationResolver struct{}
+
+func (addCommentOperationResolver) ID(ctx context.Context, obj *bug.AddCommentOperation) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (addCommentOperationResolver) Date(ctx context.Context, obj *bug.AddCommentOperation) (*time.Time, error) {
 	t := obj.Time()
 	return &t, nil
 }
 
+var _ graph.EditCommentOperationResolver = editCommentOperationResolver{}
+
 type editCommentOperationResolver struct{}
+
+func (editCommentOperationResolver) ID(ctx context.Context, obj *bug.EditCommentOperation) (string, error) {
+	return obj.Id().String(), nil
+}
+
+func (editCommentOperationResolver) Target(ctx context.Context, obj *bug.EditCommentOperation) (string, error) {
+	panic("implement me")
+}
 
 func (editCommentOperationResolver) Date(ctx context.Context, obj *bug.EditCommentOperation) (*time.Time, error) {
 	t := obj.Time()
 	return &t, nil
 }
 
-type labelChangeOperation struct{}
+var _ graph.LabelChangeOperationResolver = labelChangeOperationResolver{}
 
-func (labelChangeOperation) Date(ctx context.Context, obj *bug.LabelChangeOperation) (*time.Time, error) {
+type labelChangeOperationResolver struct{}
+
+func (labelChangeOperationResolver) ID(ctx context.Context, obj *bug.LabelChangeOperation) (string, error) {
+	return obj.Id().String(), nil
+}
+
+func (labelChangeOperationResolver) Date(ctx context.Context, obj *bug.LabelChangeOperation) (*time.Time, error) {
 	t := obj.Time()
 	return &t, nil
 }
 
+var _ graph.SetStatusOperationResolver = setStatusOperationResolver{}
+
 type setStatusOperationResolver struct{}
+
+func (setStatusOperationResolver) ID(ctx context.Context, obj *bug.SetStatusOperation) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (setStatusOperationResolver) Date(ctx context.Context, obj *bug.SetStatusOperation) (*time.Time, error) {
 	t := obj.Time()
@@ -48,7 +83,13 @@ func (setStatusOperationResolver) Status(ctx context.Context, obj *bug.SetStatus
 	return convertStatus(obj.Status)
 }
 
+var _ graph.SetTitleOperationResolver = setTitleOperationResolver{}
+
 type setTitleOperationResolver struct{}
+
+func (setTitleOperationResolver) ID(ctx context.Context, obj *bug.SetTitleOperation) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (setTitleOperationResolver) Date(ctx context.Context, obj *bug.SetTitleOperation) (*time.Time, error) {
 	t := obj.Time()

--- a/graphql/resolvers/operations.go
+++ b/graphql/resolvers/operations.go
@@ -45,7 +45,7 @@ func (editCommentOperationResolver) ID(ctx context.Context, obj *bug.EditComment
 }
 
 func (editCommentOperationResolver) Target(ctx context.Context, obj *bug.EditCommentOperation) (string, error) {
-	panic("implement me")
+	return obj.Target.String(), nil
 }
 
 func (editCommentOperationResolver) Date(ctx context.Context, obj *bug.EditCommentOperation) (*time.Time, error) {

--- a/graphql/resolvers/repo.go
+++ b/graphql/resolvers/repo.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/graphql/connections"
 	"github.com/MichaelMure/git-bug/graphql/graph"
 	"github.com/MichaelMure/git-bug/graphql/models"
@@ -38,7 +39,7 @@ func (repoResolver) AllBugs(ctx context.Context, obj *models.Repository, after *
 	source := obj.Repo.QueryBugs(query)
 
 	// The edger create a custom edge holding just the id
-	edger := func(id string, offset int) connections.Edge {
+	edger := func(id entity.Id, offset int) connections.Edge {
 		return connections.LazyBugEdge{
 			Id:     id,
 			Cursor: connections.OffsetToCursor(offset),
@@ -46,7 +47,7 @@ func (repoResolver) AllBugs(ctx context.Context, obj *models.Repository, after *
 	}
 
 	// The conMaker will finally load and compile bugs from git to replace the selected edges
-	conMaker := func(lazyBugEdges []*connections.LazyBugEdge, lazyNode []string, info *models.PageInfo, totalCount int) (*models.BugConnection, error) {
+	conMaker := func(lazyBugEdges []*connections.LazyBugEdge, lazyNode []entity.Id, info *models.PageInfo, totalCount int) (*models.BugConnection, error) {
 		edges := make([]*models.BugEdge, len(lazyBugEdges))
 		nodes := make([]*bug.Snapshot, len(lazyBugEdges))
 
@@ -99,7 +100,7 @@ func (repoResolver) AllIdentities(ctx context.Context, obj *models.Repository, a
 	source := obj.Repo.AllIdentityIds()
 
 	// The edger create a custom edge holding just the id
-	edger := func(id string, offset int) connections.Edge {
+	edger := func(id entity.Id, offset int) connections.Edge {
 		return connections.LazyIdentityEdge{
 			Id:     id,
 			Cursor: connections.OffsetToCursor(offset),
@@ -107,7 +108,7 @@ func (repoResolver) AllIdentities(ctx context.Context, obj *models.Repository, a
 	}
 
 	// The conMaker will finally load and compile identities from git to replace the selected edges
-	conMaker := func(lazyIdentityEdges []*connections.LazyIdentityEdge, lazyNode []string, info *models.PageInfo, totalCount int) (*models.IdentityConnection, error) {
+	conMaker := func(lazyIdentityEdges []*connections.LazyIdentityEdge, lazyNode []entity.Id, info *models.PageInfo, totalCount int) (*models.IdentityConnection, error) {
 		edges := make([]*models.IdentityEdge, len(lazyIdentityEdges))
 		nodes := make([]identity.Interface, len(lazyIdentityEdges))
 

--- a/graphql/resolvers/root.go
+++ b/graphql/resolvers/root.go
@@ -87,7 +87,7 @@ func (r RootResolver) EditCommentOperation() graph.EditCommentOperationResolver 
 }
 
 func (RootResolver) LabelChangeOperation() graph.LabelChangeOperationResolver {
-	return &labelChangeOperation{}
+	return &labelChangeOperationResolver{}
 }
 
 func (RootResolver) SetStatusOperation() graph.SetStatusOperationResolver {

--- a/graphql/resolvers/timeline.go
+++ b/graphql/resolvers/timeline.go
@@ -5,8 +5,11 @@ import (
 	"time"
 
 	"github.com/MichaelMure/git-bug/bug"
+	"github.com/MichaelMure/git-bug/graphql/graph"
 	"github.com/MichaelMure/git-bug/graphql/models"
 )
+
+var _ graph.CommentHistoryStepResolver = commentHistoryStepResolver{}
 
 type commentHistoryStepResolver struct{}
 
@@ -15,7 +18,13 @@ func (commentHistoryStepResolver) Date(ctx context.Context, obj *bug.CommentHist
 	return &t, nil
 }
 
+var _ graph.AddCommentTimelineItemResolver = addCommentTimelineItemResolver{}
+
 type addCommentTimelineItemResolver struct{}
+
+func (addCommentTimelineItemResolver) ID(ctx context.Context, obj *bug.AddCommentTimelineItem) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (addCommentTimelineItemResolver) CreatedAt(ctx context.Context, obj *bug.AddCommentTimelineItem) (*time.Time, error) {
 	t := obj.CreatedAt.Time()
@@ -27,7 +36,13 @@ func (addCommentTimelineItemResolver) LastEdit(ctx context.Context, obj *bug.Add
 	return &t, nil
 }
 
+var _ graph.CreateTimelineItemResolver = createTimelineItemResolver{}
+
 type createTimelineItemResolver struct{}
+
+func (createTimelineItemResolver) ID(ctx context.Context, obj *bug.CreateTimelineItem) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (createTimelineItemResolver) CreatedAt(ctx context.Context, obj *bug.CreateTimelineItem) (*time.Time, error) {
 	t := obj.CreatedAt.Time()
@@ -39,14 +54,26 @@ func (createTimelineItemResolver) LastEdit(ctx context.Context, obj *bug.CreateT
 	return &t, nil
 }
 
+var _ graph.LabelChangeTimelineItemResolver = labelChangeTimelineItem{}
+
 type labelChangeTimelineItem struct{}
+
+func (labelChangeTimelineItem) ID(ctx context.Context, obj *bug.LabelChangeTimelineItem) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (labelChangeTimelineItem) Date(ctx context.Context, obj *bug.LabelChangeTimelineItem) (*time.Time, error) {
 	t := obj.UnixTime.Time()
 	return &t, nil
 }
 
+var _ graph.SetStatusTimelineItemResolver = setStatusTimelineItem{}
+
 type setStatusTimelineItem struct{}
+
+func (setStatusTimelineItem) ID(ctx context.Context, obj *bug.SetStatusTimelineItem) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (setStatusTimelineItem) Date(ctx context.Context, obj *bug.SetStatusTimelineItem) (*time.Time, error) {
 	t := obj.UnixTime.Time()
@@ -57,7 +84,13 @@ func (setStatusTimelineItem) Status(ctx context.Context, obj *bug.SetStatusTimel
 	return convertStatus(obj.Status)
 }
 
+var _ graph.SetTitleTimelineItemResolver = setTitleTimelineItem{}
+
 type setTitleTimelineItem struct{}
+
+func (setTitleTimelineItem) ID(ctx context.Context, obj *bug.SetTitleTimelineItem) (string, error) {
+	return obj.Id().String(), nil
+}
 
 func (setTitleTimelineItem) Date(ctx context.Context, obj *bug.SetTitleTimelineItem) (*time.Time, error) {
 	t := obj.UnixTime.Time()

--- a/graphql/schema/operations.graphql
+++ b/graphql/schema/operations.graphql
@@ -1,7 +1,7 @@
 """An operation applied to a bug."""
 interface Operation {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The operations author."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -27,8 +27,8 @@ type OperationEdge {
 # Operations
 
 type CreateOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -40,8 +40,8 @@ type CreateOperation implements Operation & Authored {
 }
 
 type SetTitleOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -52,8 +52,8 @@ type SetTitleOperation implements Operation & Authored {
 }
 
 type AddCommentOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -64,21 +64,21 @@ type AddCommentOperation implements Operation & Authored {
 }
 
 type EditCommentOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
     date: Time!
 
-    target: Hash!
+    target: String!
     message: String!
     files: [Hash!]!
 }
 
 type SetStatusOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""
@@ -88,8 +88,8 @@ type SetStatusOperation implements Operation & Authored {
 }
 
 type LabelChangeOperation implements Operation & Authored {
-    """The hash of the operation"""
-    hash: Hash!
+    """The identifier of the operation"""
+    id: String!
     """The author of this object."""
     author: Identity!
     """The datetime when this operation was issued."""

--- a/graphql/schema/timeline.graphql
+++ b/graphql/schema/timeline.graphql
@@ -1,7 +1,7 @@
 """An item in the timeline of events"""
 interface TimelineItem {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
 }
 
 """CommentHistoryStep hold one version of a message in the history"""
@@ -30,8 +30,8 @@ type TimelineItemEdge {
 
 """CreateTimelineItem is a TimelineItem that represent the creation of a bug and its message edition history"""
 type CreateTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     message: String!
     messageIsEmpty: Boolean!
@@ -44,8 +44,8 @@ type CreateTimelineItem implements TimelineItem & Authored {
 
 """AddCommentTimelineItem is a TimelineItem that represent a Comment and its edition history"""
 type AddCommentTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     message: String!
     messageIsEmpty: Boolean!
@@ -58,8 +58,8 @@ type AddCommentTimelineItem implements TimelineItem & Authored {
 
 """LabelChangeTimelineItem is a TimelineItem that represent a change in the labels of a bug"""
 type LabelChangeTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     added: [Label!]!
@@ -68,8 +68,8 @@ type LabelChangeTimelineItem implements TimelineItem & Authored {
 
 """SetStatusTimelineItem is a TimelineItem that represent a change in the status of a bug"""
 type SetStatusTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     status: Status!
@@ -77,8 +77,8 @@ type SetStatusTimelineItem implements TimelineItem & Authored {
 
 """LabelChangeTimelineItem is a TimelineItem that represent a change in the title of a bug"""
 type SetTitleTimelineItem implements TimelineItem & Authored {
-    """The hash of the source operation"""
-    hash: Hash!
+    """The identifier of the source operation"""
+    id: String!
     author: Identity!
     date: Time!
     title: String!

--- a/identity/bare.go
+++ b/identity/bare.go
@@ -50,13 +50,12 @@ type bareIdentityJSON struct {
 }
 
 func (i *Bare) MarshalJSON() ([]byte, error) {
-	data, err := json.Marshal(bareIdentityJSON{
+	return json.Marshal(bareIdentityJSON{
 		Name:      i.name,
 		Email:     i.email,
 		Login:     i.login,
 		AvatarUrl: i.avatarUrl,
 	})
-	return data, err
 }
 
 func (i *Bare) UnmarshalJSON(data []byte) error {

--- a/identity/bare.go
+++ b/identity/bare.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/lamport"
 	"github.com/MichaelMure/git-bug/util/text"
@@ -13,6 +14,7 @@ import (
 )
 
 var _ Interface = &Bare{}
+var _ entity.Interface = &Bare{}
 
 // Bare is a very minimal identity, designed to be fully embedded directly along
 // other data.
@@ -20,7 +22,7 @@ var _ Interface = &Bare{}
 // in particular, this identity is designed to be compatible with the handling of
 // identities in the early version of git-bug.
 type Bare struct {
-	id        string
+	id        entity.Id
 	name      string
 	email     string
 	login     string
@@ -28,11 +30,16 @@ type Bare struct {
 }
 
 func NewBare(name string, email string) *Bare {
-	return &Bare{name: name, email: email}
+	return &Bare{id: entity.UnsetId, name: name, email: email}
 }
 
 func NewBareFull(name string, email string, login string, avatarUrl string) *Bare {
-	return &Bare{name: name, email: email, login: login, avatarUrl: avatarUrl}
+	return &Bare{id: entity.UnsetId, name: name, email: email, login: login, avatarUrl: avatarUrl}
+}
+
+func deriveId(data []byte) entity.Id {
+	sum := sha256.Sum256(data)
+	return entity.Id(fmt.Sprintf("%x", sum))
 }
 
 type bareIdentityJSON struct {
@@ -43,15 +50,19 @@ type bareIdentityJSON struct {
 }
 
 func (i *Bare) MarshalJSON() ([]byte, error) {
-	return json.Marshal(bareIdentityJSON{
+	data, err := json.Marshal(bareIdentityJSON{
 		Name:      i.name,
 		Email:     i.email,
 		Login:     i.login,
 		AvatarUrl: i.avatarUrl,
 	})
+	return data, err
 }
 
 func (i *Bare) UnmarshalJSON(data []byte) error {
+	// Compute the Id when loading the op from disk.
+	i.id = deriveId(data)
+
 	aux := bareIdentityJSON{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -67,28 +78,26 @@ func (i *Bare) UnmarshalJSON(data []byte) error {
 }
 
 // Id return the Identity identifier
-func (i *Bare) Id() string {
-	// We don't have a proper ID at hand, so let's hash all the data to get one.
-	// Hopefully the
+func (i *Bare) Id() entity.Id {
+	// We don't have a proper Id at hand, so let's hash all the data to get one.
 
-	if i.id != "" {
-		return i.id
+	if i.id == "" {
+		// something went really wrong
+		panic("identity's id not set")
 	}
+	if i.id == entity.UnsetId {
+		// This means we are trying to get the identity identifier *before* it has been stored
+		// As the Id is computed based on the actual bytes written on the disk, we are going to predict
+		// those and then get the Id. This is safe as it will be the exact same code writing on disk later.
 
-	data, err := json.Marshal(i)
-	if err != nil {
-		panic(err)
+		data, err := json.Marshal(i)
+		if err != nil {
+			panic(err)
+		}
+
+		i.id = deriveId(data)
 	}
-
-	h := fmt.Sprintf("%x", sha256.New().Sum(data)[:16])
-	i.id = string(h)
-
 	return i.id
-}
-
-// HumanId return the Identity identifier truncated for human consumption
-func (i *Bare) HumanId() string {
-	return FormatHumanID(i.Id())
 }
 
 // Name return the last version of the name

--- a/identity/bare_test.go
+++ b/identity/bare_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 func TestBare_Id(t *testing.T) {
 	i := NewBare("name", "email")
 	id := i.Id()
-	assert.Equal(t, "7b226e616d65223a226e616d65222c22", id)
+	expected := entity.Id("e18b853fbd89d5d40ca24811539c9a800c705abd9232f396954e8ca8bb63fa8a")
+	assert.Equal(t, expected, id)
 }
 
 func TestBareSerialize(t *testing.T) {
@@ -27,6 +30,8 @@ func TestBareSerialize(t *testing.T) {
 	var after Bare
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
+
+	before.id = after.id
 
 	assert.Equal(t, before, &after)
 }

--- a/identity/common.go
+++ b/identity/common.go
@@ -37,11 +37,11 @@ func UnmarshalJSON(raw json.RawMessage) (Interface, error) {
 	}
 
 	// Fallback on a legacy Bare identity
-	var b Bare
+	b := &Bare{}
 
-	err = json.Unmarshal(raw, &b)
+	err = json.Unmarshal(raw, b)
 	if err == nil && (b.name != "" || b.login != "") {
-		return &b, nil
+		return b, nil
 	}
 
 	// abort if we have an error other than the wrong type

--- a/identity/common.go
+++ b/identity/common.go
@@ -4,17 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 var ErrIdentityNotExist = errors.New("identity doesn't exist")
 
-type ErrMultipleMatch struct {
-	Matching []string
-}
-
-func (e ErrMultipleMatch) Error() string {
-	return fmt.Sprintf("Multiple matching identities found:\n%s", strings.Join(e.Matching, "\n"))
+func NewErrMultipleMatch(matching []entity.Id) *entity.ErrMultipleMatch {
+	return entity.NewErrMultipleMatch("identity", matching)
 }
 
 // Custom unmarshaling function to allow package user to delegate

--- a/identity/identity_actions.go
+++ b/identity/identity_actions.go
@@ -59,8 +59,13 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		}
 
 		for _, remoteRef := range remoteRefs {
-			refSplitted := strings.Split(remoteRef, "/")
-			id := refSplitted[len(refSplitted)-1]
+			refSplit := strings.Split(remoteRef, "/")
+			id := entity.Id(refSplit[len(refSplit)-1])
+
+			if err := id.Validate(); err != nil {
+				out <- entity.NewMergeInvalidStatus(id, errors.Wrap(err, "invalid ref").Error())
+				continue
+			}
 
 			remoteIdentity, err := read(repo, remoteRef)
 

--- a/identity/identity_actions.go
+++ b/identity/identity_actions.go
@@ -75,7 +75,7 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 				continue
 			}
 
-			localRef := identityRefPattern + remoteIdentity.Id()
+			localRef := identityRefPattern + remoteIdentity.Id().String()
 			localExist, err := repo.RefExist(localRef)
 
 			if err != nil {

--- a/identity/identity_stub.go
+++ b/identity/identity_stub.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"encoding/json"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/lamport"
 	"github.com/MichaelMure/git-bug/util/timestamp"
@@ -16,13 +17,13 @@ var _ Interface = &IdentityStub{}
 // When this JSON is deserialized, an IdentityStub is returned instead, to be replaced
 // later by the proper Identity, loaded from the Repo.
 type IdentityStub struct {
-	id string
+	id entity.Id
 }
 
 func (i *IdentityStub) MarshalJSON() ([]byte, error) {
 	// TODO: add a type marker
 	return json.Marshal(struct {
-		Id string `json:"id"`
+		Id entity.Id `json:"id"`
 	}{
 		Id: i.id,
 	})
@@ -30,7 +31,7 @@ func (i *IdentityStub) MarshalJSON() ([]byte, error) {
 
 func (i *IdentityStub) UnmarshalJSON(data []byte) error {
 	aux := struct {
-		Id string `json:"id"`
+		Id entity.Id `json:"id"`
 	}{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -43,13 +44,8 @@ func (i *IdentityStub) UnmarshalJSON(data []byte) error {
 }
 
 // Id return the Identity identifier
-func (i *IdentityStub) Id() string {
+func (i *IdentityStub) Id() entity.Id {
 	return i.id
-}
-
-// HumanId return the Identity identifier truncated for human consumption
-func (i *IdentityStub) HumanId() string {
-	return FormatHumanID(i.Id())
 }
 
 func (IdentityStub) Name() string {

--- a/identity/identity_stub_test.go
+++ b/identity/identity_stub_test.go
@@ -19,5 +19,8 @@ func TestIdentityStubSerialize(t *testing.T) {
 	err = json.Unmarshal(data, &after)
 	assert.NoError(t, err)
 
+	// enforce creating the Id
+	before.Id()
+
 	assert.Equal(t, before, &after)
 }

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,6 +16,7 @@ func TestIdentityCommitLoad(t *testing.T) {
 	// single version
 
 	identity := &Identity{
+		id: entity.UnsetId,
 		versions: []*Version{
 			{
 				name:  "René Descartes",
@@ -36,6 +38,7 @@ func TestIdentityCommitLoad(t *testing.T) {
 	// multiple version
 
 	identity = &Identity{
+		id: entity.UnsetId,
 		versions: []*Version{
 			{
 				time:  100,
@@ -114,6 +117,7 @@ func commitsAreSet(t *testing.T, identity *Identity) {
 // Test that the correct crypto keys are returned for a given lamport time
 func TestIdentity_ValidKeysAtTime(t *testing.T) {
 	identity := Identity{
+		id: entity.UnsetId,
 		versions: []*Version{
 			{
 				time:  100,
@@ -215,6 +219,7 @@ func TestJSON(t *testing.T) {
 	mockRepo := repository.NewMockRepoForTest()
 
 	identity := &Identity{
+		id: entity.UnsetId,
 		versions: []*Version{
 			{
 				name:  "René Descartes",
@@ -223,7 +228,7 @@ func TestJSON(t *testing.T) {
 		},
 	}
 
-	// commit to make sure we have an ID
+	// commit to make sure we have an Id
 	err := identity.Commit(mockRepo)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, identity.id)

--- a/identity/interface.go
+++ b/identity/interface.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/lamport"
 	"github.com/MichaelMure/git-bug/util/timestamp"
@@ -8,10 +9,7 @@ import (
 
 type Interface interface {
 	// Id return the Identity identifier
-	Id() string
-
-	// HumanId return the Identity identifier truncated for human consumption
-	HumanId() string
+	Id() entity.Id
 
 	// Name return the last version of the name
 	Name() string

--- a/identity/resolver.go
+++ b/identity/resolver.go
@@ -1,11 +1,14 @@
 package identity
 
-import "github.com/MichaelMure/git-bug/repository"
+import (
+	"github.com/MichaelMure/git-bug/entity"
+	"github.com/MichaelMure/git-bug/repository"
+)
 
 // Resolver define the interface of an Identity resolver, able to load
 // an identity from, for example, a repo or a cache.
 type Resolver interface {
-	ResolveIdentity(id string) (Interface, error)
+	ResolveIdentity(id entity.Id) (Interface, error)
 }
 
 // DefaultResolver is a Resolver loading Identities directly from a Repo
@@ -17,6 +20,6 @@ func NewSimpleResolver(repo repository.Repo) *SimpleResolver {
 	return &SimpleResolver{repo: repo}
 }
 
-func (r *SimpleResolver) ResolveIdentity(id string) (Interface, error) {
+func (r *SimpleResolver) ResolveIdentity(id entity.Id) (Interface, error) {
 	return ReadLocal(r.repo, id)
 }

--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -25,7 +25,7 @@ type bugTable struct {
 	repo         *cache.RepoCache
 	queryStr     string
 	query        *cache.Query
-	allIds       []string
+	allIds       []entity.Id
 	excerpts     []*cache.BugExcerpt
 	pageCursor   int
 	selectCursor int
@@ -308,7 +308,7 @@ func (bt *bugTable) render(v *gocui.View, maxX int) {
 
 		lastEditTime := time.Unix(excerpt.EditUnixTime, 0)
 
-		id := text.LeftPadMaxLine(excerpt.HumanId(), columnWidths["id"], 1)
+		id := text.LeftPadMaxLine(excerpt.Id.Human(), columnWidths["id"], 1)
 		status := text.LeftPadMaxLine(excerpt.Status.String(), columnWidths["status"], 1)
 		title := text.LeftPadMaxLine(excerpt.Title, columnWidths["title"], 1)
 		author := text.LeftPadMaxLine(authorDisplayName, columnWidths["author"], 1)
@@ -482,7 +482,7 @@ func (bt *bugTable) pull(g *gocui.Gui, v *gocui.View) error {
 				})
 			} else {
 				_, _ = fmt.Fprintf(&buffer, "%s%s: %s",
-					beginLine, colors.Cyan(result.Entity.HumanId()), result,
+					beginLine, colors.Cyan(result.Entity.Id().Human()), result,
 				)
 
 				beginLine = "\n"

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -8,7 +8,6 @@ import (
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/util/colors"
-	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/git-bug/util/text"
 	"github.com/MichaelMure/gocui"
 )
@@ -232,7 +231,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	y0 += lines + 1
 
 	for _, op := range snap.Timeline {
-		viewName := op.Hash().String()
+		viewName := op.ID()
 
 		// TODO: me might skip the rendering of blocks that are outside of the view
 		// but to do that we need to rework how sb.mainSelectableView is maintained
@@ -643,7 +642,7 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return nil
 	}
 
-	op, err := snap.SearchTimelineItem(git.Hash(sb.selected))
+	op, err := snap.SearchTimelineItem(sb.selected)
 	if err != nil {
 		return err
 	}
@@ -651,10 +650,10 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 	switch op.(type) {
 	case *bug.AddCommentTimelineItem:
 		message := op.(*bug.AddCommentTimelineItem).Message
-		return editCommentWithEditor(sb.bug, op.Hash(), message)
+		return editCommentWithEditor(sb.bug, op.ID(), message)
 	case *bug.CreateTimelineItem:
 		preMessage := op.(*bug.CreateTimelineItem).Message
-		return editCommentWithEditor(sb.bug, op.Hash(), preMessage)
+		return editCommentWithEditor(sb.bug, op.ID(), preMessage)
 	case *bug.LabelChangeTimelineItem:
 		return sb.editLabels(g, snap)
 	}

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/text"
 	"github.com/MichaelMure/gocui"
@@ -213,7 +214,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	}
 
 	bugHeader := fmt.Sprintf("[%s] %s\n\n[%s] %s opened this bug on %s%s",
-		colors.Cyan(snap.HumanId()),
+		colors.Cyan(snap.Id().Human()),
 		colors.Bold(snap.Title),
 		colors.Yellow(snap.Status),
 		colors.Magenta(snap.Author.DisplayName()),
@@ -231,7 +232,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 	y0 += lines + 1
 
 	for _, op := range snap.Timeline {
-		viewName := op.ID()
+		viewName := op.Id().String()
 
 		// TODO: me might skip the rendering of blocks that are outside of the view
 		// but to do that we need to rework how sb.mainSelectableView is maintained
@@ -642,7 +643,7 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return nil
 	}
 
-	op, err := snap.SearchTimelineItem(sb.selected)
+	op, err := snap.SearchTimelineItem(entity.Id(sb.selected))
 	if err != nil {
 		return err
 	}
@@ -650,10 +651,10 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 	switch op.(type) {
 	case *bug.AddCommentTimelineItem:
 		message := op.(*bug.AddCommentTimelineItem).Message
-		return editCommentWithEditor(sb.bug, op.ID(), message)
+		return editCommentWithEditor(sb.bug, op.Id(), message)
 	case *bug.CreateTimelineItem:
 		preMessage := op.(*bug.CreateTimelineItem).Message
-		return editCommentWithEditor(sb.bug, op.ID(), preMessage)
+		return editCommentWithEditor(sb.bug, op.Id(), preMessage)
 	case *bug.LabelChangeTimelineItem:
 		return sb.editLabels(g, snap)
 	}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/input"
 )
 
@@ -237,7 +238,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	return errTerminateMainloop
 }
 
-func editCommentWithEditor(bug *cache.BugCache, target string, preMessage string) error {
+func editCommentWithEditor(bug *cache.BugCache, target entity.Id, preMessage string) error {
 	// This is somewhat hacky.
 	// As there is no way to pause gocui, run the editor and restart gocui,
 	// we have to stop it entirely and start a new one later.

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -2,11 +2,11 @@
 package termui
 
 import (
-	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/input"
-	"github.com/MichaelMure/git-bug/util/git"
 	"github.com/MichaelMure/gocui"
 	"github.com/pkg/errors"
+
+	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/input"
 )
 
 var errTerminateMainloop = errors.New("terminate gocui mainloop")
@@ -237,7 +237,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	return errTerminateMainloop
 }
 
-func editCommentWithEditor(bug *cache.BugCache, target git.Hash, preMessage string) error {
+func editCommentWithEditor(bug *cache.BugCache, target string, preMessage string) error {
 	// This is somewhat hacky.
 	// As there is no way to pause gocui, run the editor and restart gocui,
 	// we have to stop it entirely and start a new one later.

--- a/util/git/hash.go
+++ b/util/git/hash.go
@@ -5,6 +5,9 @@ import (
 	"io"
 )
 
+const idLengthSHA1 = 40
+const idLengthSHA256 = 64
+
 // Hash is a git hash
 type Hash string
 
@@ -16,7 +19,7 @@ func (h Hash) String() string {
 func (h *Hash) UnmarshalGQL(v interface{}) error {
 	_, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("labels must be strings")
+		return fmt.Errorf("hashes must be strings")
 	}
 
 	*h = v.(Hash)
@@ -35,7 +38,8 @@ func (h Hash) MarshalGQL(w io.Writer) {
 
 // IsValid tell if the hash is valid
 func (h *Hash) IsValid() bool {
-	if len(*h) != 40 && len(*h) != 64 {
+	// Support for both sha1 and sha256 git hashes
+	if len(*h) != idLengthSHA1 && len(*h) != idLengthSHA256 {
 		return false
 	}
 	for _, r := range *h {


### PR DESCRIPTION
- Fix a potential problem where en operation's ID would change if go's json code changed
- rename Hash to ID to be consistent
- ID() doesn't return an error anymore

I'm still pondering if a custom type should be used instead of `string` (kind of like how `git.Hash` was used, but without any relation to git).