### PR TITLE
bridge: allow to configure and pull without having set a user first

### DIFF
--- a/bridge/core/auth/token.go
+++ b/bridge/core/auth/token.go
@@ -59,6 +59,10 @@ func (t *Token) UserId() entity.Id {
 	return t.userId
 }
 
+func (t *Token) updateUserId(id entity.Id) {
+	t.userId = id
+}
+
 func (t *Token) Target() string {
 	return t.target
 }
@@ -88,7 +92,7 @@ func (t *Token) Validate() error {
 	return nil
 }
 
-func (t *Token) ToConfig() map[string]string {
+func (t *Token) toConfig() map[string]string {
 	return map[string]string{
 		tokenValueKey: t.Value,
 	}

--- a/bridge/github/config.go
+++ b/bridge/github/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge/core/auth"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/entity"
+	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
@@ -89,8 +90,14 @@ func (g *Github) Configure(repo *cache.RepoCache, params core.BridgeParams) (cor
 	}
 
 	user, err := repo.GetUserIdentity()
-	if err != nil {
+	if err != nil && err != identity.ErrNoIdentitySet {
 		return nil, err
+	}
+
+	// default to a "to be filled" user Id if we don't have a valid one yet
+	userId := auth.DefaultUserId
+	if user != nil {
+		userId = user.Id()
 	}
 
 	var cred auth.Credential
@@ -101,13 +108,13 @@ func (g *Github) Configure(repo *cache.RepoCache, params core.BridgeParams) (cor
 		if err != nil {
 			return nil, err
 		}
-		if cred.UserId() != user.Id() {
+		if user != nil && cred.UserId() != user.Id() {
 			return nil, fmt.Errorf("selected credential don't match the user")
 		}
 	case params.TokenRaw != "":
-		cred = auth.NewToken(user.Id(), params.TokenRaw, target)
+		cred = auth.NewToken(userId, params.TokenRaw, target)
 	default:
-		cred, err = promptTokenOptions(repo, user.Id(), owner, project)
+		cred, err = promptTokenOptions(repo, userId, owner, project)
 		if err != nil {
 			return nil, err
 		}
@@ -326,7 +333,7 @@ func promptToken() (string, error) {
 			return token, nil
 		}
 
-		fmt.Println("token is invalid")
+		fmt.Println("token has incorrect format")
 	}
 }
 

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/entity"
+	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -46,6 +47,9 @@ func (gi *githubImporter) Init(repo *cache.RepoCache, conf core.Configuration) e
 	user, err := repo.GetUserIdentity()
 	if err == nil {
 		opts = append(opts, auth.WithUserId(user.Id()))
+	}
+	if err == identity.ErrNoIdentitySet {
+		opts = append(opts, auth.WithUserId(auth.DefaultUserId))
 	}
 
 	creds, err := auth.List(repo, opts...)

--- a/bridge/github/import_test.go
+++ b/bridge/github/import_test.go
@@ -143,6 +143,9 @@ func Test_Importer(t *testing.T) {
 	err = author.Commit(repo)
 	require.NoError(t, err)
 
+	err = identity.SetUserIdentity(repo, author)
+	require.NoError(t, err)
+
 	token := auth.NewToken(author.Id(), envToken, target)
 	err = auth.Store(repo, token)
 	require.NoError(t, err)

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/entity"
+	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/text"
 )
 
@@ -41,6 +42,9 @@ func (gi *gitlabImporter) Init(repo *cache.RepoCache, conf core.Configuration) e
 	user, err := repo.GetUserIdentity()
 	if err == nil {
 		opts = append(opts, auth.WithUserId(user.Id()))
+	}
+	if err == identity.ErrNoIdentitySet {
+		opts = append(opts, auth.WithUserId(auth.DefaultUserId))
 	}
 
 	creds, err := auth.List(repo, opts...)

--- a/bridge/gitlab/import_test.go
+++ b/bridge/gitlab/import_test.go
@@ -97,6 +97,9 @@ func TestImport(t *testing.T) {
 	err = author.Commit(repo)
 	require.NoError(t, err)
 
+	err = identity.SetUserIdentity(repo, author)
+	require.NoError(t, err)
+
 	token := auth.NewToken(author.Id(), envToken, target)
 	err = auth.Store(repo, token)
 	require.NoError(t, err)

--- a/commands/bridge_auth.go
+++ b/commands/bridge_auth.go
@@ -37,14 +37,21 @@ func runBridgeAuth(cmd *cobra.Command, args []string) error {
 			value = cred.Value
 		}
 
-		user, err := backend.ResolveIdentity(cred.UserId())
-		if err != nil {
-			return err
-		}
-		userFmt := user.DisplayName()
+		var userFmt string
 
-		if cred.UserId() == defaultUser.Id() {
-			userFmt = colors.Red(userFmt)
+		switch cred.UserId() {
+		case auth.DefaultUserId:
+			userFmt = colors.Red("default user")
+		default:
+			user, err := backend.ResolveIdentity(cred.UserId())
+			if err != nil {
+				return err
+			}
+			userFmt = user.DisplayName()
+
+			if cred.UserId() == defaultUser.Id() {
+				userFmt = colors.Red(userFmt)
+			}
 		}
 
 		fmt.Printf("%s %s %s %s %s\n",

--- a/commands/bridge_auth_show.go
+++ b/commands/bridge_auth_show.go
@@ -7,17 +7,46 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/MichaelMure/git-bug/bridge/core/auth"
+	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/util/colors"
+	"github.com/MichaelMure/git-bug/util/interrupt"
 )
 
 func runBridgeAuthShow(cmd *cobra.Command, args []string) error {
+	backend, err := cache.NewRepoCache(repo)
+	if err != nil {
+		return err
+	}
+	defer backend.Close()
+	interrupt.RegisterCleaner(backend.Close)
+
 	cred, err := auth.LoadWithPrefix(repo, args[0])
 	if err != nil {
 		return err
 	}
 
+	var userFmt string
+
+	switch cred.UserId() {
+	case auth.DefaultUserId:
+		userFmt = colors.Red("default user")
+	default:
+		user, err := backend.ResolveIdentity(cred.UserId())
+		if err != nil {
+			return err
+		}
+		userFmt = user.DisplayName()
+
+		defaultUser, _ := backend.GetUserIdentity()
+		if cred.UserId() == defaultUser.Id() {
+			userFmt = colors.Red(userFmt)
+		}
+	}
+
 	fmt.Printf("Id: %s\n", cred.ID())
 	fmt.Printf("Target: %s\n", cred.Target())
 	fmt.Printf("Kind: %s\n", cred.Kind())
+	fmt.Printf("User: %s\n", userFmt)
 	fmt.Printf("Creation: %s\n", cred.CreateTime().Format(time.RFC822))
 
 	switch cred := cred.(type) {

--- a/commands/bridge_configure.go
+++ b/commands/bridge_configure.go
@@ -206,7 +206,7 @@ git bug bridge configure \
     --target=github \
     --url=https://github.com/michaelmure/git-bug \
     --token=$(TOKEN)`,
-	PreRunE: loadRepoEnsureUser,
+	PreRunE: loadRepo,
 	RunE:    runBridgeConfigure,
 }
 

--- a/commands/bridge_pull.go
+++ b/commands/bridge_pull.go
@@ -138,7 +138,7 @@ func parseSince(since string) (time.Time, error) {
 var bridgePullCmd = &cobra.Command{
 	Use:     "pull [<name>]",
 	Short:   "Pull updates.",
-	PreRunE: loadRepoEnsureUser,
+	PreRunE: loadRepo,
 	RunE:    runBridgePull,
 	Args:    cobra.MaximumNArgs(1),
 }

--- a/commands/user_adopt.go
+++ b/commands/user_adopt.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MichaelMure/git-bug/bridge/core/auth"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +23,16 @@ func runUserAdopt(cmd *cobra.Command, args []string) error {
 
 	i, err := backend.ResolveIdentityPrefix(prefix)
 	if err != nil {
+		return err
+	}
+
+	_, err = backend.GetUserIdentity()
+	if err == identity.ErrNoIdentitySet {
+		err = auth.ReplaceDefaultUser(repo, i.Id())
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I was writing a how-to to explain how to use git-bug as a remote for an external bugtracker and I realized I was not happy with the UX. The problem is that you have to 1) create a temporary user, 2) configure the bridge, 3) pull the bugs and identities and 4) adopt the actual identity you want to use.

This PR change that to a simpler workflow: 1) configure the bridge, 2) pull the bugs and identities and 3) adopt your user. This is done by assigning a temporary "default user" to the new credential that will be set properly later when `user adopt` is run.

Detail is as follow:
- init() only the importer or exporter as required
- assign a "default user" user Id to credentials at creation if no user has been set
- `bridge auth`: also display the user
- `bridge auth show`: adapt to a potential "default user" user Id
- `bridge configure`: allow to run without a user set
- `bridge pull`: allow to run without a user set
- `user adopt`: replace "default user" by the actual user id when run

What do you guys think ?