### PR TITLE
Github import error

### DIFF
--- a/bridge/core/bridge.go
+++ b/bridge/core/bridge.go
@@ -347,7 +347,7 @@ func (b *Bridge) ImportAllSince(ctx context.Context, since time.Time) (<-chan Im
 
 		// relay all events while checking that everything went well
 		for event := range events {
-			if event.Err != nil {
+			if event.Event == ImportEventError {
 				noError = false
 			}
 			out <- event

--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -29,6 +29,10 @@ const (
 
 	// Error happened during export
 	ExportEventError
+
+	// Something wrong happened during export that is worth notifying to the user
+	// but not severe enough to consider the export a failure.
+	ExportEventWarning
 )
 
 // ExportResult is an event that is emitted during the export process, to
@@ -65,6 +69,11 @@ func (er ExportResult) String() string {
 			return fmt.Sprintf("export error at %s: %s", er.ID, er.Err.Error())
 		}
 		return fmt.Sprintf("export error: %s", er.Err.Error())
+	case ExportEventWarning:
+		if er.ID != "" {
+			return fmt.Sprintf("warning at %s: %s", er.ID, er.Err.Error())
+		}
+		return fmt.Sprintf("warning: %s", er.Err.Error())
 
 	default:
 		panic("unknown export result")
@@ -76,6 +85,14 @@ func NewExportError(err error, id entity.Id) ExportResult {
 		ID:    id,
 		Err:   err,
 		Event: ExportEventError,
+	}
+}
+
+func NewExportWarning(err error, id entity.Id) ExportResult {
+	return ExportResult{
+		ID:    id,
+		Err:   err,
+		Event: ExportEventWarning,
 	}
 }
 

--- a/bridge/core/import.go
+++ b/bridge/core/import.go
@@ -31,6 +31,10 @@ const (
 
 	// Error happened during import
 	ImportEventError
+
+	// Something wrong happened during import that is worth notifying to the user
+	// but not severe enough to consider the import a failure.
+	ImportEventWarning
 )
 
 // ImportResult is an event that is emitted during the import process, to
@@ -69,6 +73,12 @@ func (er ImportResult) String() string {
 			return fmt.Sprintf("import error at id %s: %s", er.ID, er.Err.Error())
 		}
 		return fmt.Sprintf("import error: %s", er.Err.Error())
+	case ImportEventWarning:
+		if er.ID != "" {
+			return fmt.Sprintf("warning at id %s: %s", er.ID, er.Err.Error())
+		}
+		return fmt.Sprintf("warning: %s", er.Err.Error())
+
 	default:
 		panic("unknown import result")
 	}
@@ -79,6 +89,14 @@ func NewImportError(err error, id entity.Id) ImportResult {
 		Err:   err,
 		ID:    id,
 		Event: ImportEventError,
+	}
+}
+
+func NewImportWarning(err error, id entity.Id) ImportResult {
+	return ImportResult{
+		Err:   err,
+		ID:    id,
+		Event: ImportEventWarning,
 	}
 }
 

--- a/bridge/core/import.go
+++ b/bridge/core/import.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MichaelMure/git-bug/entity"
 )
@@ -74,10 +75,18 @@ func (er ImportResult) String() string {
 		}
 		return fmt.Sprintf("import error: %s", er.Err.Error())
 	case ImportEventWarning:
+		parts := make([]string, 0, 4)
+		parts = append(parts, "warning:")
 		if er.ID != "" {
-			return fmt.Sprintf("warning at id %s: %s", er.ID, er.Err.Error())
+			parts = append(parts, fmt.Sprintf("at id %s", er.ID))
 		}
-		return fmt.Sprintf("warning: %s", er.Err.Error())
+		if er.Reason != "" {
+			parts = append(parts, fmt.Sprintf("reason: %s", er.Reason))
+		}
+		if er.Err != nil {
+			parts = append(parts, fmt.Sprintf("err: %s", er.Err))
+		}
+		return strings.Join(parts, " ")
 
 	default:
 		panic("unknown import result")

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -201,6 +201,11 @@ func (gi *githubImporter) ensureIssue(repo *cache.RepoCache, issue issueTimeline
 
 			// other edits will be added as CommentEdit operations
 			target, err := b.ResolveOperationWithMetadata(metaKeyGithubId, parseId(issue.Id))
+			if err == cache.ErrNoMatchingOp {
+				// original comment is missing somehow, issuing a warning
+				gi.out <- core.NewImportWarning(fmt.Errorf("comment ID %s to edit is missing", parseId(issue.Id)), b.Id())
+				continue
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/repository/config_git.go
+++ b/repository/config_git.go
@@ -66,11 +66,7 @@ func (gc *gitConfig) ReadAll(keyPrefix string) (map[string]string, error) {
 			continue
 		}
 
-		parts := strings.Fields(line)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("bad git config: %s", line)
-		}
-
+		parts := strings.SplitN(line, " ", 2)
 		result[parts[0]] = parts[1]
 	}
 


### PR DESCRIPTION
This PR is an attempt to fix #286 

My understanding is that when trying to import a comment edition, if the original comment is nowhere to be found locally the import will hard fail with an error. This kinda make sense because the comment really should be there but that also an assumption we can relax a bit I think. A warning might be enough.

@cheshirekow I cherry-picked from your PR the two commits introducing warning in the bridge's core (one completely, one while remove the Jira related changes). Rebasing your PR should go without too much though.