### PR TITLE
jira: rework to use the credential system + adapt to refactors

### DIFF
--- a/bridge/jira/config.go
+++ b/bridge/jira/config.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/MichaelMure/git-bug/bridge/core"
@@ -104,7 +105,7 @@ func (j *Jira) Configure(repo *cache.RepoCache, params core.BridgeParams) (core.
 	}
 
 	fmt.Printf("Attempting to login with credentials...\n")
-	client, err := buildClient(nil, baseURL, credType, cred)
+	client, err := buildClient(context.TODO(), baseURL, credType, cred)
 	if err != nil {
 		return nil, err
 	}

--- a/bridge/jira/config.go
+++ b/bridge/jira/config.go
@@ -1,15 +1,13 @@
 package jira
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-
-	"github.com/pkg/errors"
 
 	"github.com/MichaelMure/git-bug/bridge/core"
+	"github.com/MichaelMure/git-bug/bridge/core/auth"
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/input"
+	"github.com/MichaelMure/git-bug/repository"
 )
 
 const moreConfigText = `
@@ -28,32 +26,27 @@ after October 1st 2019 must use "TOKEN" authentication. You must create a user
 API token and the client will provide this along with your username with each
 request.`
 
-// Configure sets up the bridge configuration
-func (g *Jira) Configure(repo *cache.RepoCache, params core.BridgeParams) (core.Configuration, error) {
-	conf := make(core.Configuration)
-	conf[core.ConfigKeyTarget] = target
+func (*Jira) ValidParams() map[string]interface{} {
+	return map[string]interface{}{
+		"BaseURL":    nil,
+		"Login":      nil,
+		"CredPrefix": nil,
+		"Project":    nil,
+	}
+}
 
+// Configure sets up the bridge configuration
+func (j *Jira) Configure(repo *cache.RepoCache, params core.BridgeParams) (core.Configuration, error) {
 	var err error
 
-	// if params.Token != "" || params.TokenStdin {
-	// 	return nil, fmt.Errorf(
-	// 		"JIRA session tokens are extremely short lived. We don't store them " +
-	// 			"in the configuration, so they are not valid for this bridge.")
-	// }
-
-	if params.Owner != "" {
-		fmt.Println("warning: --owner is ineffective for a Jira bridge")
-	}
-
-	serverURL := params.URL
-	if serverURL == "" {
+	baseURL := params.BaseURL
+	if baseURL == "" {
 		// terminal prompt
-		serverURL, err = input.Prompt("JIRA server URL", "URL", input.Required)
+		baseURL, err = input.Prompt("JIRA server URL", "URL", input.Required, input.IsURL)
 		if err != nil {
 			return nil, err
 		}
 	}
-	conf[keyServer] = serverURL
 
 	project := params.Project
 	if project == "" {
@@ -62,77 +55,56 @@ func (g *Jira) Configure(repo *cache.RepoCache, params core.BridgeParams) (core.
 			return nil, err
 		}
 	}
-	conf[keyProject] = project
 
 	fmt.Println(credTypeText)
-	credType, err := input.PromptChoice("Authentication mechanism", []string{"SESSION", "TOKEN"})
+	credTypeInput, err := input.PromptChoice("Authentication mechanism", []string{"SESSION", "TOKEN"})
 	if err != nil {
 		return nil, err
 	}
+	credType := []string{"SESSION", "TOKEN"}[credTypeInput]
 
-	switch credType {
-	case 1:
-		conf[keyCredentialsType] = "SESSION"
-	case 2:
-		conf[keyCredentialsType] = "TOKEN"
-	}
+	var login string
+	var cred auth.Credential
 
-	fmt.Println("How would you like to store your JIRA login credentials?")
-	credTargetChoice, err := input.PromptChoice("Credential storage", []string{
-		"sidecar JSON file: Your credentials will be stored in a JSON sidecar next" +
-			"to your git config. Note that it will contain your JIRA password in clear" +
-			"text.",
-		"git-config: Your credentials will be stored in the git config. Note that" +
-			"it will contain your JIRA password in clear text.",
-		"username in config, askpass: Your username will be stored in the git" +
-			"config. We will ask you for your password each time you execute the bridge.",
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	username, err := input.Prompt("JIRA username", "username", input.Required)
-	if err != nil {
-		return nil, err
-	}
-
-	password, err := input.PromptPassword("Password", "password", input.Required)
-	if err != nil {
-		return nil, err
-	}
-
-	switch credTargetChoice {
-	case 1:
-		// TODO: a validator to see if the path is writable ?
-		credentialsFile, err := input.Prompt("Credentials file path", "path", input.Required)
+	switch {
+	case params.CredPrefix != "":
+		cred, err = auth.LoadWithPrefix(repo, params.CredPrefix)
 		if err != nil {
 			return nil, err
 		}
-		conf[keyCredentialsFile] = credentialsFile
-		jsonData, err := json.Marshal(&SessionQuery{Username: username, Password: password})
+		l, ok := cred.GetMetadata(auth.MetaKeyLogin)
+		if !ok {
+			return nil, fmt.Errorf("credential doesn't have a login")
+		}
+		login = l
+	default:
+		login := params.Login
+		if login == "" {
+			// TODO: validate username
+			login, err = input.Prompt("JIRA login", "login", input.Required)
+			if err != nil {
+				return nil, err
+			}
+		}
+		cred, err = promptCredOptions(repo, login, baseURL)
 		if err != nil {
 			return nil, err
 		}
-		err = ioutil.WriteFile(credentialsFile, jsonData, 0644)
-		if err != nil {
-			return nil, errors.Wrap(
-				err, fmt.Sprintf("Unable to write credentials to %s", credentialsFile))
-		}
-	case 2:
-		conf[keyUsername] = username
-		conf[keyPassword] = password
-	case 3:
-		conf[keyUsername] = username
 	}
 
-	err = g.ValidateConfig(conf)
+	conf := make(core.Configuration)
+	conf[core.ConfigKeyTarget] = target
+	conf[confKeyBaseUrl] = baseURL
+	conf[confKeyProject] = project
+	conf[confKeyCredentialType] = credType
+
+	err = j.ValidateConfig(conf)
 	if err != nil {
 		return nil, err
 	}
 
 	fmt.Printf("Attempting to login with credentials...\n")
-	client := NewClient(serverURL, nil)
-	err = client.Login(conf)
+	client, err := buildClient(nil, baseURL, credType, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +116,12 @@ func (g *Jira) Configure(repo *cache.RepoCache, params core.BridgeParams) (core.
 		return nil, fmt.Errorf(
 			"Project %s doesn't exist on %s, or authentication credentials for (%s)"+
 				" are invalid",
-			project, serverURL, username)
+			project, baseURL, login)
+	}
+
+	err = core.FinishConfig(repo, metaKeyJiraLogin, login)
+	if err != nil {
+		return nil, err
 	}
 
 	fmt.Print(moreConfigText)
@@ -159,9 +136,46 @@ func (*Jira) ValidateConfig(conf core.Configuration) error {
 		return fmt.Errorf("unexpected target name: %v", v)
 	}
 
-	if _, ok := conf[keyProject]; !ok {
-		return fmt.Errorf("missing %s key", keyProject)
+	if _, ok := conf[confKeyProject]; !ok {
+		return fmt.Errorf("missing %s key", confKeyProject)
 	}
 
 	return nil
+}
+
+func promptCredOptions(repo repository.RepoConfig, login, baseUrl string) (auth.Credential, error) {
+	creds, err := auth.List(repo,
+		auth.WithTarget(target),
+		auth.WithKind(auth.KindToken),
+		auth.WithMeta(auth.MetaKeyLogin, login),
+		auth.WithMeta(auth.MetaKeyBaseURL, baseUrl),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cred, index, err := input.PromptCredential(target, "password", creds, []string{
+		"enter my password",
+		"ask my password each time",
+	})
+	switch {
+	case err != nil:
+		return nil, err
+	case cred != nil:
+		return cred, nil
+	case index == 0:
+		password, err := input.PromptPassword("Password", "password", input.Required)
+		if err != nil {
+			return nil, err
+		}
+		lp := auth.NewLoginPassword(target, login, password)
+		lp.SetMetadata(auth.MetaKeyLogin, login)
+		return lp, nil
+	case index == 1:
+		l := auth.NewLogin(target, login)
+		l.SetMetadata(auth.MetaKeyLogin, login)
+		return l, nil
+	default:
+		panic("missed case")
+	}
 }


### PR DESCRIPTION
@cheshirekow this PR adapt the Jira bridge to the credential system and to all the refactor I did recently. Please have a look

Note: It compiles but I can't test myself (automated tests would be veeery useful).
Note: the base of this PR is your branch pushed on this remote, otherwise I can't PR on it

A few questions:
- do you think it would be possible to detect automatically the credential (session or token) ? That would simplify both the code and the UX
- there is a mismatch between the name and value of this constant, what's the good concept ? metaKeyJiraOperationId = "jira-derived-id"
- it looks it would be very easy to support the official hosted Jira instances, it should simply be a default value in the baseURL prompt (see gitlab). What do you think ?

