### PR TITLE
Supports git config includes

### DIFF
--- a/repository/config_git.go
+++ b/repository/config_git.go
@@ -45,7 +45,7 @@ func (gc *gitConfig) StoreTimestamp(key string, value time.Time) error {
 
 // ReadAll read all key/value pair matching the key prefix
 func (gc *gitConfig) ReadAll(keyPrefix string) (map[string]string, error) {
-	stdout, err := gc.repo.runGitCommand("config", gc.localityFlag, "--get-regexp", keyPrefix)
+	stdout, err := gc.repo.runGitCommand("config", gc.localityFlag, "--includes", "--get-regexp", keyPrefix)
 
 	//   / \
 	//  / ! \
@@ -74,7 +74,7 @@ func (gc *gitConfig) ReadAll(keyPrefix string) (map[string]string, error) {
 }
 
 func (gc *gitConfig) ReadString(key string) (string, error) {
-	stdout, err := gc.repo.runGitCommand("config", gc.localityFlag, "--get-all", key)
+	stdout, err := gc.repo.runGitCommand("config", gc.localityFlag, "--includes", "--get-all", key)
 
 	//   / \
 	//  / ! \


### PR DESCRIPTION
I like to have "private" settings in a git include file, and store the
main .gitconfig under version control. I do not want any authentication
keys or tokens (even if encrypted) in version control, so I have by main
.gitconfig include another file which is local and not tracked.

The current implementation calls `git config --global --get-regexp
<keyPrefix>` and for some reason, this command does not follow git
include files.

The changes suggested in this PR add the `--includes` flag to the
command, which then reads any included files.