### PR TITLE
termui: fix a crash when trying to open a bug when there are none

### DIFF
--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -437,6 +437,10 @@ func (bt *bugTable) newBug(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (bt *bugTable) openBug(g *gocui.Gui, v *gocui.View) error {
+	if len(bt.excerpts) == 0 {
+		// There are no open bugs, just do nothing
+		return nil
+	}
 	id := bt.excerpts[bt.selectCursor].Id
 	b, err := bt.repo.ResolveBug(id)
 	if err != nil {


### PR DESCRIPTION
Nothing prevented you from pressing Enter in bug listing even when there
were no open bugs. Doing so resulted in:

panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/MichaelMure/git-bug/termui.(*bugTable).openBug(0xc00007aa80, 0xc000354000, 0xc00036c120, 0x2, 0x2)
        /build/source/termui/bug_table.go:440 +0x17f
github.com/awesome-gocui/gocui.(*Gui).execKeybinding(0xc000354000, 0xc00036c120, 0xc0003102a0, 0xc00007a001, 0xc000225b2c, 0xc000000180)
        /build/go/pkg/mod/github.com/awesome-gocui/gocui@v0.6.1-0.20191115151952-a34ffb055986/gui.go:808 +0x65
github.com/awesome-gocui/gocui.(*Gui).execKeybindings(0xc000354000, 0xc00036c120, 0xc000225b38, 0x3, 0x4, 0x3)
        /build/go/pkg/mod/github.com/awesome-gocui/gocui@v0.6.1-0.20191115151952-a34ffb055986/gui.go:787 +0xed
github.com/awesome-gocui/gocui.(*Gui).onKey(0xc000354000, 0xc000225b38, 0x2, 0x0)
        /build/go/pkg/mod/github.com/awesome-gocui/gocui@v0.6.1-0.20191115151952-a34ffb055986/gui.go:745 +0x164
github.com/awesome-gocui/gocui.(*Gui).handleEvent(...)
        /build/go/pkg/mod/github.com/awesome-gocui/gocui@v0.6.1-0.20191115151952-a34ffb055986/gui.go:506
github.com/awesome-gocui/gocui.(*Gui).MainLoop(0xc000354000, 0x0, 0x0)
        /build/go/pkg/mod/github.com/awesome-gocui/gocui@v0.6.1-0.20191115151952-a34ffb055986/gui.go:466 +0x202
github.com/MichaelMure/git-bug/termui.initGui(0x0)
        /build/source/termui/termui.go:113 +0x12c
github.com/MichaelMure/git-bug/termui.Run(0xc000228000, 0xc000078b30, 0x0)
        /build/source/termui/termui.go:66 +0x185
github.com/MichaelMure/git-bug/commands.runTermUI(0x1211bc0, 0x12478e0, 0x0, 0x0, 0x0, 0x0)
        /build/source/commands/termui.go:18 +0xd5
github.com/spf13/cobra.(*Command).execute(0x1211bc0, 0x12478e0, 0x0, 0x0, 0x1211bc0, 0x12478e0)
        /build/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:840 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0x1210960, 0x0, 0x0, 0x0)
        /build/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:945 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
        /build/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:885
github.com/MichaelMure/git-bug/commands.Execute()
        /build/source/commands/root.go:54 +0x2d
main.main()
        /build/source/git-bug.go:14 +0x20