### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ That's all !
 
 </details>
 
+<details><summary>macOS packages</summary>
+
+* [Homebrew](https://formulae.brew.sh/formula/git-bug)
+  ```
+  brew install git-bug
+  ```
+
+</details>
+
 <details><summary>Compile from git (unstable)</summary>
 
 ```shell


### PR DESCRIPTION
Thanks to @uraimo's https://github.com/Homebrew/homebrew-core/pull/53016 PR, option to install git-bug through Homebrew on macOS is now possible.