### PR TITLE
DOC: commands/root.go: syntax

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -25,7 +25,7 @@ var RootCmd = &cobra.Command{
 
 git-bug use git objects to store the bug tracking separated from the files
 history. As bugs are regular git objects, they can be pushed and pulled from/to
-the same git remote your are already using to collaborate with other peoples.
+the same git remote you are already using to collaborate with other people.
 
 `,
 


### PR DESCRIPTION
This probably needs to also be built in order to update the cli --help and the man page? IDK how that's done?