### PR TITLE
Add formatting options to the 'show' and 'user ls' commands

### DIFF
--- a/bridge/github/export.go
+++ b/bridge/github/export.go
@@ -173,7 +173,7 @@ func (ge *githubExporter) ExportAll(ctx context.Context, repo *cache.RepoCache, 
 
 				// ignore issues created before since date
 				// TODO: compare the Lamport time instead of using the unix time
-				if snapshot.CreatedAt.Before(since) {
+				if snapshot.CreateTime.Before(since) {
 					out <- core.NewExportNothing(b.Id(), "bug created before the since date")
 					continue
 				}

--- a/bridge/gitlab/export.go
+++ b/bridge/gitlab/export.go
@@ -131,7 +131,7 @@ func (ge *gitlabExporter) ExportAll(ctx context.Context, repo *cache.RepoCache, 
 
 				// ignore issues created before since date
 				// TODO: compare the Lamport time instead of using the unix time
-				if snapshot.CreatedAt.Before(since) {
+				if snapshot.CreateTime.Before(since) {
 					out <- core.NewExportNothing(b.Id(), "bug created before the since date")
 					continue
 				}

--- a/bridge/jira/export.go
+++ b/bridge/jira/export.go
@@ -165,7 +165,7 @@ func (je *jiraExporter) ExportAll(ctx context.Context, repo *cache.RepoCache, si
 
 				// ignore issues whose last modification date is before the query date
 				// TODO: compare the Lamport time instead of using the unix time
-				if snapshot.CreatedAt.Before(since) {
+				if snapshot.CreateTime.Before(since) {
 					out <- core.NewExportNothing(b.Id(), "bug created before the since date")
 					continue
 				}

--- a/bug/op_create.go
+++ b/bug/op_create.go
@@ -48,7 +48,7 @@ func (op *CreateOperation) Apply(snapshot *Snapshot) {
 
 	snapshot.Comments = []Comment{comment}
 	snapshot.Author = op.Author
-	snapshot.CreatedAt = op.Time()
+	snapshot.CreateTime = op.Time()
 
 	snapshot.Timeline = []TimelineItem{
 		&CreateTimelineItem{

--- a/bug/op_create_test.go
+++ b/bug/op_create_test.go
@@ -38,7 +38,7 @@ func TestCreate(t *testing.T) {
 		Author:       rene,
 		Participants: []identity.Interface{rene},
 		Actors:       []identity.Interface{rene},
-		CreatedAt:    create.Time(),
+		CreateTime:   create.Time(),
 		Timeline: []TimelineItem{
 			&CreateTimelineItem{
 				CommentTimelineItem: NewCommentTimelineItem(id, comment),

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -19,7 +19,7 @@ type Snapshot struct {
 	Author       identity.Interface
 	Actors       []identity.Interface
 	Participants []identity.Interface
-	CreatedAt    time.Time
+	CreateTime   time.Time
 
 	Timeline []TimelineItem
 
@@ -32,21 +32,12 @@ func (snap *Snapshot) Id() entity.Id {
 }
 
 // Return the last time a bug was modified
-func (snap *Snapshot) LastEditTime() time.Time {
+func (snap *Snapshot) EditTime() time.Time {
 	if len(snap.Operations) == 0 {
 		return time.Unix(0, 0)
 	}
 
 	return snap.Operations[len(snap.Operations)-1].Time()
-}
-
-// Return the last timestamp a bug was modified
-func (snap *Snapshot) LastEditUnix() int64 {
-	if len(snap.Operations) == 0 {
-		return 0
-	}
-
-	return snap.Operations[len(snap.Operations)-1].GetUnixTime()
 }
 
 // GetCreateMetadata return the creation metadata

--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"encoding/gob"
 	"fmt"
+	"time"
 
 	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/entity"
@@ -22,8 +23,8 @@ type BugExcerpt struct {
 
 	CreateLamportTime lamport.Time
 	EditLamportTime   lamport.Time
-	CreateUnixTime    int64
-	EditUnixTime      int64
+	createUnixTime    int64
+	editUnixTime      int64
 
 	Status       bug.Status
 	Labels       []bug.Label
@@ -79,8 +80,8 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 		Id:                b.Id(),
 		CreateLamportTime: b.CreateLamportTime(),
 		EditLamportTime:   b.EditLamportTime(),
-		CreateUnixTime:    b.FirstOp().GetUnixTime(),
-		EditUnixTime:      snap.LastEditUnix(),
+		createUnixTime:    b.FirstOp().Time().Unix(),
+		editUnixTime:      snap.EditTime().Unix(),
 		Status:            snap.Status,
 		Labels:            snap.Labels,
 		Actors:            actorsIds,
@@ -103,6 +104,14 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 	}
 
 	return e
+}
+
+func (b *BugExcerpt) CreateTime() time.Time {
+	return time.Unix(b.createUnixTime, 0)
+}
+
+func (b *BugExcerpt) EditTime() time.Time {
+	return time.Unix(b.editUnixTime, 0)
 }
 
 /*
@@ -144,7 +153,7 @@ func (b BugsByCreationTime) Less(i, j int) bool {
 	// by the first sorting using the logical clock. That means that if users
 	// synchronize their bugs regularly, the timestamp will rarely be used, and
 	// should still provide a kinda accurate sorting when needed.
-	return b[i].CreateUnixTime < b[j].CreateUnixTime
+	return b[i].createUnixTime < b[j].createUnixTime
 }
 
 func (b BugsByCreationTime) Swap(i, j int) {
@@ -172,7 +181,7 @@ func (b BugsByEditTime) Less(i, j int) bool {
 	// by the first sorting using the logical clock. That means that if users
 	// synchronize their bugs regularly, the timestamp will rarely be used, and
 	// should still provide a kinda accurate sorting when needed.
-	return b[i].EditUnixTime < b[j].EditUnixTime
+	return b[i].editUnixTime < b[j].editUnixTime
 }
 
 func (b BugsByEditTime) Swap(i, j int) {

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -32,14 +32,6 @@ const identityCacheFile = "identity-cache"
 // 3: CreateUnixTime --> createUnixTime, EditUnixTime --> editUnixTime
 const formatVersion = 3
 
-type ErrInvalidCacheFormat struct {
-	message string
-}
-
-func (e ErrInvalidCacheFormat) Error() string {
-	return e.message
-}
-
 var _ repository.RepoCommon = &RepoCache{}
 
 // RepoCache is a cache for a Repository. This cache has multiple functions:
@@ -100,13 +92,8 @@ func NewNamedRepoCache(r repository.ClockedRepo, name string) (*RepoCache, error
 	if err == nil {
 		return c, nil
 	}
-	if _, ok := err.(ErrInvalidCacheFormat); !ok {
-		// Actual error
-		return nil, err
-	}
 
-	// We have an outdated cache format, rebuilding it.
-
+	// Cache is either missing, broken or outdated. Rebuilding.
 	err = c.buildCache()
 	if err != nil {
 		return nil, err
@@ -259,9 +246,7 @@ func (c *RepoCache) loadBugCache() error {
 	}
 
 	if aux.Version != formatVersion {
-		return ErrInvalidCacheFormat{
-			message: fmt.Sprintf("unknown cache format version %v", aux.Version),
-		}
+		return fmt.Errorf("unknown cache format version %v", aux.Version)
 	}
 
 	c.bugExcerpts = aux.Excerpts
@@ -291,9 +276,7 @@ func (c *RepoCache) loadIdentityCache() error {
 	}
 
 	if aux.Version != formatVersion {
-		return ErrInvalidCacheFormat{
-			message: fmt.Sprintf("unknown cache format version %v", aux.Version),
-		}
+		return fmt.Errorf("unknown cache format version %v", aux.Version)
 	}
 
 	c.identitiesExcerpts = aux.Excerpts

--- a/commands/json_common.go
+++ b/commands/json_common.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/identity"
+	"github.com/MichaelMure/git-bug/util/lamport"
+)
+
+type JSONIdentity struct {
+	Id      string `json:"id"`
+	HumanId string `json:"human_id"`
+	Name    string `json:"name"`
+	Login   string `json:"login"`
+}
+
+func NewJSONIdentity(i identity.Interface) JSONIdentity {
+	return JSONIdentity{
+		Id:      i.Id().String(),
+		HumanId: i.Id().Human(),
+		Name:    i.Name(),
+		Login:   i.Login(),
+	}
+}
+
+func NewJSONIdentityFromExcerpt(excerpt *cache.IdentityExcerpt) JSONIdentity {
+	return JSONIdentity{
+		Id:      excerpt.Id.String(),
+		HumanId: excerpt.Id.Human(),
+		Name:    excerpt.Name,
+		Login:   excerpt.Login,
+	}
+}
+
+func NewJSONIdentityFromLegacyExcerpt(excerpt *cache.LegacyAuthorExcerpt) JSONIdentity {
+	return JSONIdentity{
+		Name:  excerpt.Name,
+		Login: excerpt.Login,
+	}
+}
+
+type JSONTime struct {
+	Timestamp int64        `json:"timestamp"`
+	Time      time.Time    `json:"time"`
+	Lamport   lamport.Time `json:"lamport,omitempty"`
+}
+
+func NewJSONTime(t time.Time, l lamport.Time) JSONTime {
+	return JSONTime{
+		Timestamp: t.Unix(),
+		Time:      t,
+		Lamport:   l,
+	}
+}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -95,18 +95,15 @@ func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) 
 	jsonBugs := make([]JSONBugExcerpt, len(bugExcerpts))
 	for i, b := range bugExcerpts {
 		jsonBug := JSONBugExcerpt{
-			b.Id.String(),
-			b.Id.Human(),
-			time.Unix(b.CreateUnixTime, 0),
-			time.Unix(b.EditUnixTime, 0),
-			b.Status.String(),
-			b.Labels,
-			b.Title,
-			[]JSONIdentity{},
-			[]JSONIdentity{},
-			JSONIdentity{},
-			b.LenComments,
-			b.CreateMetadata,
+			Id:           b.Id.String(),
+			HumanId:      b.Id.Human(),
+			CreationTime: time.Unix(b.CreateUnixTime, 0),
+			LastEdited:   time.Unix(b.EditUnixTime, 0),
+			Status:       b.Status.String(),
+			Labels:       b.Labels,
+			Title:        b.Title,
+			Comments:     b.LenComments,
+			Metadata:     b.CreateMetadata,
 		}
 
 		if b.AuthorId != "" {
@@ -114,46 +111,27 @@ func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) 
 			if err != nil {
 				return err
 			}
-
-			i, err := NewJSONIdentity(author)
-			if err != nil {
-				return err
-			}
-			jsonBug.Author = i
+			jsonBug.Author = NewJSONIdentityFromExcerpt(author)
 		} else {
-			i, err := NewJSONIdentity(b.LegacyAuthor)
-			if err != nil {
-				return err
-			}
-			jsonBug.Author = i
+			jsonBug.Author = NewJSONIdentityFromLegacyExcerpt(&b.LegacyAuthor)
 		}
 
-		for _, element := range b.Actors {
+		jsonBug.Actors = make([]JSONIdentity, len(b.Actors))
+		for i, element := range b.Actors {
 			actor, err := backend.ResolveIdentityExcerpt(element)
 			if err != nil {
 				return err
 			}
-
-			i, err := NewJSONIdentity(actor)
-			if err != nil {
-				return err
-			}
-
-			jsonBug.Actors = append(jsonBug.Actors, i)
+			jsonBug.Actors[i] = NewJSONIdentityFromExcerpt(actor)
 		}
 
-		for _, element := range b.Participants {
+		jsonBug.Participants = make([]JSONIdentity, len(b.Participants))
+		for i, element := range b.Participants {
 			participant, err := backend.ResolveIdentityExcerpt(element)
 			if err != nil {
 				return err
 			}
-
-			i, err := NewJSONIdentity(participant)
-			if err != nil {
-				return err
-			}
-
-			jsonBug.Participants = append(jsonBug.Participants, i)
+			jsonBug.Participants[i] = NewJSONIdentityFromExcerpt(participant)
 		}
 
 		jsonBugs[i] = jsonBug

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -115,13 +115,17 @@ func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) 
 				return err
 			}
 
-			jsonBug.Author.Name = author.DisplayName()
-			jsonBug.Author.Login = author.Login
-			jsonBug.Author.Id = author.Id.String()
-			jsonBug.Author.HumanId = author.Id.Human()
+			i, err := NewJSONIdentity(author)
+			if err != nil {
+				return err
+			}
+			jsonBug.Author = i
 		} else {
-			jsonBug.Author.Name = b.LegacyAuthor.DisplayName()
-			jsonBug.Author.Login = b.LegacyAuthor.Login
+			i, err := NewJSONIdentity(b.LegacyAuthor)
+			if err != nil {
+				return err
+			}
+			jsonBug.Author = i
 		}
 
 		for _, element := range b.Actors {
@@ -130,12 +134,12 @@ func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) 
 				return err
 			}
 
-			jsonBug.Actors = append(jsonBug.Actors, JSONIdentity{
-				actor.Id.String(),
-				actor.Id.Human(),
-				actor.Name,
-				actor.Login,
-			})
+			i, err := NewJSONIdentity(actor)
+			if err != nil {
+				return err
+			}
+
+			jsonBug.Actors = append(jsonBug.Actors, i)
 		}
 
 		for _, element := range b.Participants {
@@ -143,12 +147,13 @@ func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) 
 			if err != nil {
 				return err
 			}
-			jsonBug.Participants = append(jsonBug.Participants, JSONIdentity{
-				participant.Id.String(),
-				participant.Id.Human(),
-				participant.DisplayName(),
-				participant.Login,
-			})
+
+			i, err := NewJSONIdentity(participant)
+			if err != nil {
+				return err
+			}
+
+			jsonBug.Participants = append(jsonBug.Participants, i)
 		}
 
 		jsonBugs[i] = jsonBug
@@ -232,11 +237,9 @@ func lsOrgmodeFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerp
 		}
 
 		labels := b.Labels
-		labelsString := ":"
+		var labelsString string
 		if len(labels) > 0 {
-			for _, label := range labels {
-				labelsString += label.String() + ":"
-			}
+			labelsString = fmt.Sprintf(":%s:", strings.Replace(fmt.Sprint(labels), " ", ":", -1))
 		} else {
 			labelsString = ""
 		}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -72,7 +72,7 @@ func runLsBug(_ *cobra.Command, args []string) error {
 	}
 }
 
-type JSONBug struct {
+type JSONBugExcerpt struct {
 	Id           string    `json:"id"`
 	HumanId      string    `json:"human_id"`
 	CreationTime time.Time `json:"creation_time"`
@@ -89,17 +89,10 @@ type JSONBug struct {
 	Metadata map[string]string `json:"metadata"`
 }
 
-type JSONIdentity struct {
-	Id      string `json:"id"`
-	HumanId string `json:"human_id"`
-	Name    string `json:"name"`
-	Login   string `json:"login"`
-}
-
 func lsJsonFormatter(backend *cache.RepoCache, bugExcerpts []*cache.BugExcerpt) error {
-	jsonBugs := make([]JSONBug, len(bugExcerpts))
+	jsonBugs := make([]JSONBugExcerpt, len(bugExcerpts))
 	for i, b := range bugExcerpts {
-		jsonBug := JSONBug{
+		jsonBug := JSONBugExcerpt{
 			b.Id.String(),
 			b.Id.Human(),
 			time.Unix(b.CreateUnixTime, 0),
@@ -294,5 +287,5 @@ func init() {
 	lsCmd.Flags().StringVarP(&lsSortDirection, "direction", "d", "asc",
 		"Select the sorting direction. Valid values are [asc,desc]")
 	lsCmd.Flags().StringVarP(&lsOutputFormat, "format", "f", "default",
-		"Select the output formatting style. Valid values are [default, plain(text), json]")
+		"Select the output formatting style. Valid values are [default,plain,json]")
 }

--- a/commands/show.go
+++ b/commands/show.go
@@ -351,7 +351,9 @@ func showOrgmodeFormatter(snapshot *bug.Snapshot) error {
 
 	fmt.Printf("* Labels:\n")
 	if len(labels) > 0 {
-		fmt.Printf("** %s", strings.TrimSuffix(strings.Join(labels, "\n **"), "\n **"))
+		fmt.Printf("** %s\n",
+			strings.Join(labels, "\n** "),
+		)
 	}
 
 	// Actors
@@ -363,28 +365,28 @@ func showOrgmodeFormatter(snapshot *bug.Snapshot) error {
 		)
 	}
 
-	fmt.Printf("* Actors: %s\n",
-		strings.TrimSuffix(strings.Join(actors, "\n **"), "\n **"),
+	fmt.Printf("* Actors:\n** %s\n",
+		strings.Join(actors, "\n** "),
 	)
 
 	// Participants
 	var participants = make([]string, len(snapshot.Participants))
 	for i, participant := range snapshot.Participants {
-		actors[i] = fmt.Sprintf("%s %s",
+		participants[i] = fmt.Sprintf("%s %s",
 			participant.Id().Human(),
 			participant.DisplayName(),
 		)
 	}
 
-	fmt.Printf("* Participants: %s\n",
-		strings.TrimSuffix(strings.Join(participants, "\n **"), "\n **"),
+	fmt.Printf("* Participants:\n** %s\n",
+		strings.Join(participants, "\n** "),
 	)
 
 	fmt.Printf("* Comments:\n")
 
 	for i, comment := range snapshot.Comments {
 		var message string
-		fmt.Printf("** #%d %s [%s]\n",
+		fmt.Printf("** #%d %s\n",
 			i,
 			comment.Author.DisplayName(),
 		)

--- a/commands/show.go
+++ b/commands/show.go
@@ -1,22 +1,25 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-
+	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/cache"
 	_select "github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
+	"strings"
+	"time"
 )
 
 var (
-	showFieldsQuery string
+	showFieldsQuery  string
+	showOutputFormat string
 )
 
-func runShowBug(cmd *cobra.Command, args []string) error {
+func runShowBug(_ *cobra.Command, args []string) error {
 	backend, err := cache.NewRepoCache(repo)
 	if err != nil {
 		return err
@@ -35,16 +38,16 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		return errors.New("invalid bug: no comment")
 	}
 
-	firstComment := snapshot.Comments[0]
-
 	if showFieldsQuery != "" {
 		switch showFieldsQuery {
 		case "author":
-			fmt.Printf("%s\n", firstComment.Author.DisplayName())
+			fmt.Printf("%s\n", snapshot.Author.DisplayName())
 		case "authorEmail":
-			fmt.Printf("%s\n", firstComment.Author.Email())
+			fmt.Printf("%s\n", snapshot.Author.Email())
 		case "createTime":
-			fmt.Printf("%s\n", firstComment.FormatTime())
+			fmt.Printf("%s\n", snapshot.CreatedAt.String())
+		case "lastEdit":
+			fmt.Printf("%s\n", snapshot.LastEditTime().String())
 		case "humanId":
 			fmt.Printf("%s\n", snapshot.Id().Human())
 		case "id":
@@ -74,6 +77,19 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	switch showOutputFormat {
+	case "json":
+		return showJsonFormatter(snapshot)
+	case "plain":
+		return showPlainFormatter(snapshot)
+	case "default":
+		return showDefaultFormatter(snapshot)
+	default:
+		return fmt.Errorf("unknown format %s", showOutputFormat)
+	}
+}
+
+func showDefaultFormatter(snapshot *bug.Snapshot) error {
 	// Header
 	fmt.Printf("[%s] %s %s\n\n",
 		colors.Yellow(snapshot.Status),
@@ -81,9 +97,13 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 		snapshot.Title,
 	)
 
-	fmt.Printf("%s opened this issue %s\n\n",
-		colors.Magenta(firstComment.Author.DisplayName()),
-		firstComment.FormatTimeRel(),
+	fmt.Printf("%s opened this issue %s\n",
+		colors.Magenta(snapshot.Author.DisplayName()),
+		snapshot.CreatedAt.String(),
+	)
+
+	fmt.Printf("This was last edited at %s\n\n",
+		snapshot.LastEditTime().String(),
 	)
 
 	// Labels
@@ -143,6 +163,165 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func showPlainFormatter(snapshot *bug.Snapshot) error {
+	// Header
+	fmt.Printf("[%s] %s %s\n",
+		snapshot.Status,
+		snapshot.Id().Human(),
+		snapshot.Title,
+	)
+
+	fmt.Printf("author: %s\n",
+		snapshot.Author.DisplayName(),
+	)
+
+	fmt.Printf("creation time: %s\n",
+		snapshot.CreatedAt.String(),
+	)
+
+	fmt.Printf("last edit: %s\n",
+		snapshot.LastEditTime().String(),
+	)
+
+	// Labels
+	var labels = make([]string, len(snapshot.Labels))
+	for i := range snapshot.Labels {
+		labels[i] = string(snapshot.Labels[i])
+	}
+
+	fmt.Printf("labels: %s\n",
+		strings.Join(labels, ", "),
+	)
+
+	// Actors
+	var actors = make([]string, len(snapshot.Actors))
+	for i := range snapshot.Actors {
+		actors[i] = snapshot.Actors[i].DisplayName()
+	}
+
+	fmt.Printf("actors: %s\n",
+		strings.Join(actors, ", "),
+	)
+
+	// Participants
+	var participants = make([]string, len(snapshot.Participants))
+	for i := range snapshot.Participants {
+		participants[i] = snapshot.Participants[i].DisplayName()
+	}
+
+	fmt.Printf("participants: %s\n",
+		strings.Join(participants, ", "),
+	)
+
+	// Comments
+	indent := "  "
+
+	for i, comment := range snapshot.Comments {
+		var message string
+		fmt.Printf("%s#%d %s <%s>\n",
+			indent,
+			i,
+			comment.Author.DisplayName(),
+			comment.Author.Email(),
+		)
+
+		if comment.Message == "" {
+			message = "No description provided."
+		} else {
+			message = comment.Message
+		}
+
+		fmt.Printf("%s%s\n",
+			indent,
+			message,
+		)
+	}
+
+	return nil
+}
+
+type JSONBugSnapshot struct {
+	Id           string    `json:"id"`
+	HumanId      string    `json:"human_id"`
+	CreationTime time.Time `json:"creation_time"`
+	LastEdited   time.Time `json:"last_edited"`
+
+	Status       string         `json:"status"`
+	Labels       []bug.Label    `json:"labels"`
+	Title        string         `json:"title"`
+	Author       JSONIdentity   `json:"author"`
+	Actors       []JSONIdentity `json:"actors"`
+	Participants []JSONIdentity `json:"participants"`
+
+	Comments []JSONComment `json:"comments"`
+}
+
+type JSONComment struct {
+	Id          int    `json:"id"`
+	AuthorName  string `json:"author_name"`
+	AuthorLogin string `json:"author_login"`
+	Message     string `json:"message"`
+}
+
+func showJsonFormatter(snapshot *bug.Snapshot) error {
+	jsonBug := JSONBugSnapshot{
+		snapshot.Id().String(),
+		snapshot.Id().Human(),
+		snapshot.CreatedAt,
+		snapshot.LastEditTime(),
+		snapshot.Status.String(),
+		snapshot.Labels,
+		snapshot.Title,
+		JSONIdentity{},
+		[]JSONIdentity{},
+		[]JSONIdentity{},
+		[]JSONComment{},
+	}
+
+	jsonBug.Author.Name = snapshot.Author.DisplayName()
+	jsonBug.Author.Login = snapshot.Author.Login()
+	jsonBug.Author.Id = snapshot.Author.Id().String()
+	jsonBug.Author.HumanId = snapshot.Author.Id().Human()
+
+	for _, element := range snapshot.Actors {
+		jsonBug.Actors = append(jsonBug.Actors, JSONIdentity{
+			element.Id().String(),
+			element.Id().Human(),
+			element.Name(),
+			element.Login(),
+		})
+	}
+
+	for _, element := range snapshot.Participants {
+		jsonBug.Actors = append(jsonBug.Actors, JSONIdentity{
+			element.Id().String(),
+			element.Id().Human(),
+			element.Name(),
+			element.Login(),
+		})
+	}
+
+	for i, comment := range snapshot.Comments {
+		var message string
+		if comment.Message == "" {
+			message = "No description provided."
+		} else {
+			message = comment.Message
+		}
+		jsonBug.Comments = append(jsonBug.Comments, JSONComment{
+			i,
+			comment.Author.Name(),
+			comment.Author.Login(),
+			message,
+		})
+	}
+
+	jsonObject, _ := json.MarshalIndent(jsonBug, "", "    ")
+	fmt.Printf("%s\n", jsonObject)
+
+	return nil
+}
+
 var showCmd = &cobra.Command{
 	Use:     "show [<id>]",
 	Short:   "Display the details of a bug.",
@@ -152,6 +331,8 @@ var showCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(showCmd)
-	showCmd.Flags().StringVarP(&showFieldsQuery, "field", "f", "",
-		"Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]")
+	showCmd.Flags().StringVarP(&showFieldsQuery, "field", "", "",
+		"Select field to display. Valid values are [author,authorEmail,createTime,lastEdit,humanId,id,labels,shortId,status,title,actors,participants]")
+	showCmd.Flags().StringVarP(&showOutputFormat, "format", "f", "default",
+		"Select the output formatting style. Valid values are [default,plain,json]")
 }

--- a/commands/show.go
+++ b/commands/show.go
@@ -235,7 +235,7 @@ func showPlainFormatter(snapshot *bug.Snapshot) error {
 
 		fmt.Printf("%s%s\n",
 			indent,
-			message,
+			strings.ReplaceAll(message, "\n", fmt.Sprintf("\n%s", indent)),
 		)
 	}
 
@@ -280,27 +280,26 @@ func showJsonFormatter(snapshot *bug.Snapshot) error {
 		[]JSONComment{},
 	}
 
-	jsonBug.Author.Name = snapshot.Author.DisplayName()
-	jsonBug.Author.Login = snapshot.Author.Login()
-	jsonBug.Author.Id = snapshot.Author.Id().String()
-	jsonBug.Author.HumanId = snapshot.Author.Id().Human()
+	author, err := NewJSONIdentity(snapshot.Author)
+	if err != nil {
+		return err
+	}
+	jsonBug.Author = author
 
 	for _, element := range snapshot.Actors {
-		jsonBug.Actors = append(jsonBug.Actors, JSONIdentity{
-			element.Id().String(),
-			element.Id().Human(),
-			element.Name(),
-			element.Login(),
-		})
+		actor, err := NewJSONIdentity(element)
+		if err != nil {
+			return err
+		}
+		jsonBug.Actors = append(jsonBug.Actors, actor)
 	}
 
 	for _, element := range snapshot.Participants {
-		jsonBug.Actors = append(jsonBug.Actors, JSONIdentity{
-			element.Id().String(),
-			element.Id().Human(),
-			element.Name(),
-			element.Login(),
-		})
+		participant, err := NewJSONIdentity(element)
+		if err != nil {
+			return err
+		}
+		jsonBug.Participants = append(jsonBug.Participants, participant)
 	}
 
 	for i, comment := range snapshot.Comments {
@@ -393,7 +392,7 @@ func showOrgmodeFormatter(snapshot *bug.Snapshot) error {
 		if comment.Message == "" {
 			message = "No description provided."
 		} else {
-			message = strings.Replace(comment.Message, "\n", "\n: ", -1)
+			message = strings.ReplaceAll(comment.Message, "\n", "\n: ")
 		}
 
 		fmt.Printf(": %s\n",

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -2,11 +2,16 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
+
+	"github.com/spf13/cobra"
+
 	"github.com/MichaelMure/git-bug/cache"
+	identity2 "github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -21,15 +26,25 @@ func runUserLs(_ *cobra.Command, _ []string) error {
 	defer backend.Close()
 	interrupt.RegisterCleaner(backend.Close)
 
+	ids := backend.AllIdentityIds()
+	var users []*cache.IdentityExcerpt
+	for _, id := range ids {
+		user, err := backend.ResolveIdentityExcerpt(id)
+		if err != nil {
+			return err
+		}
+		users = append(users, user)
+	}
+
 	switch userLsOutputFormat {
 	case "org-mode":
-		return userLsOrgmodeFormatter(backend)
+		return userLsOrgmodeFormatter(users)
 	case "json":
-		return userLsJsonFormatter(backend)
+		return userLsJsonFormatter(users)
 	case "plain":
-		return userLsPlainFormatter(backend)
+		return userLsPlainFormatter(users)
 	case "default":
-		return userLsDefaultFormatter(backend)
+		return userLsDefaultFormatter(users)
 	default:
 		return fmt.Errorf("unknown format %s", userLsOutputFormat)
 	}
@@ -42,69 +57,79 @@ type JSONIdentity struct {
 	Login   string `json:"login"`
 }
 
-func userLsPlainFormatter(backend *cache.RepoCache) error {
-	for _, id := range backend.AllIdentityIds() {
-		i, err := backend.ResolveIdentityExcerpt(id)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s %s\n",
-			i.Id.Human(),
-			i.DisplayName(),
-		)
-	}
-
-	return nil
-}
-
-func userLsDefaultFormatter(backend *cache.RepoCache) error {
-	for _, id := range backend.AllIdentityIds() {
-		i, err := backend.ResolveIdentityExcerpt(id)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s %s\n",
-			colors.Cyan(i.Id.Human()),
-			i.DisplayName(),
-		)
-	}
-
-	return nil
-}
-
-func userLsJsonFormatter(backend *cache.RepoCache) error {
-	users := []JSONIdentity{}
-	for _, id := range backend.AllIdentityIds() {
-		i, err := backend.ResolveIdentityExcerpt(id)
-		if err != nil {
-			return err
-		}
-
-		users = append(users, JSONIdentity{
+func NewJSONIdentity(id interface{}) (JSONIdentity, error) {
+	switch id.(type) {
+	case *cache.IdentityExcerpt:
+		i := id.(*cache.IdentityExcerpt)
+		return JSONIdentity{
 			i.Id.String(),
 			i.Id.Human(),
 			i.Name,
 			i.Login,
-		})
+		}, nil
+	case identity2.Interface:
+		i := id.(identity2.Interface)
+		return JSONIdentity{
+			i.Id().String(),
+			i.Id().Human(),
+			i.Name(),
+			i.Login(),
+		}, nil
+	case cache.LegacyAuthorExcerpt:
+		i := id.(cache.LegacyAuthorExcerpt)
+		return JSONIdentity{
+			nil,
+			nil,
+			i.Name,
+			i.Login,
+		}, nil
+	default:
+		return JSONIdentity{}, errors.New(fmt.Sprintf("Inconvertible type, attempting to convert type %s to type %s.", reflect.TypeOf(id).String(), reflect.TypeOf(JSONIdentity{}).String()))
+	}
+}
+
+func userLsPlainFormatter(users []*cache.IdentityExcerpt) error {
+	for _, user := range users {
+		fmt.Printf("%s %s\n",
+			user.Id.Human(),
+			user.DisplayName(),
+		)
 	}
 
-	jsonObject, _ := json.MarshalIndent(users, "", "    ")
+	return nil
+}
+
+func userLsDefaultFormatter(users []*cache.IdentityExcerpt) error {
+	for _, user := range users {
+		fmt.Printf("%s %s\n",
+			colors.Cyan(user.Id.Human()),
+			user.DisplayName(),
+		)
+	}
+
+	return nil
+}
+
+func userLsJsonFormatter(users []*cache.IdentityExcerpt) error {
+	jsonUsers := []JSONIdentity{}
+	for _, user := range users {
+		jsonUser, err := NewJSONIdentity(user)
+		if err != nil {
+			return err
+		}
+		jsonUsers = append(jsonUsers, jsonUser)
+	}
+
+	jsonObject, _ := json.MarshalIndent(jsonUsers, "", "    ")
 	fmt.Printf("%s\n", jsonObject)
 	return nil
 }
 
-func userLsOrgmodeFormatter(backend *cache.RepoCache) error {
-	for _, id := range backend.AllIdentityIds() {
-		i, err := backend.ResolveIdentityExcerpt(id)
-		if err != nil {
-			return err
-		}
-
+func userLsOrgmodeFormatter(users []*cache.IdentityExcerpt) error {
+	for _, user := range users {
 		fmt.Printf("* %s %s\n",
-			i.Id.Human(),
-			i.DisplayName(),
+			user.Id.Human(),
+			user.DisplayName(),
 		)
 	}
 

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -78,8 +78,8 @@ func NewJSONIdentity(id interface{}) (JSONIdentity, error) {
 	case cache.LegacyAuthorExcerpt:
 		i := id.(cache.LegacyAuthorExcerpt)
 		return JSONIdentity{
-			nil,
-			nil,
+			"",
+			"",
 			i.Name,
 			i.Login,
 		}, nil

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/MichaelMure/git-bug/cache"
-	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
 )
@@ -41,38 +40,6 @@ func runUserLs(_ *cobra.Command, _ []string) error {
 		return userLsDefaultFormatter(users)
 	default:
 		return fmt.Errorf("unknown format %s", userLsOutputFormat)
-	}
-}
-
-type JSONIdentity struct {
-	Id      string `json:"id"`
-	HumanId string `json:"human_id"`
-	Name    string `json:"name"`
-	Login   string `json:"login"`
-}
-
-func NewJSONIdentity(i identity.Interface) JSONIdentity {
-	return JSONIdentity{
-		Id:      i.Id().String(),
-		HumanId: i.Id().Human(),
-		Name:    i.Name(),
-		Login:   i.Login(),
-	}
-}
-
-func NewJSONIdentityFromExcerpt(excerpt *cache.IdentityExcerpt) JSONIdentity {
-	return JSONIdentity{
-		Id:      excerpt.Id.String(),
-		HumanId: excerpt.Id.Human(),
-		Name:    excerpt.Name,
-		Login:   excerpt.Login,
-	}
-}
-
-func NewJSONIdentityFromLegacyExcerpt(excerpt *cache.LegacyAuthorExcerpt) JSONIdentity {
-	return JSONIdentity{
-		Name:  excerpt.Name,
-		Login: excerpt.Login,
 	}
 }
 

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -22,6 +22,8 @@ func runUserLs(_ *cobra.Command, _ []string) error {
 	interrupt.RegisterCleaner(backend.Close)
 
 	switch userLsOutputFormat {
+	case "org-mode":
+		return userLsOrgmodeFormatter(backend)
 	case "json":
 		return userLsJsonFormatter(backend)
 	case "plain":
@@ -93,6 +95,22 @@ func userLsJsonFormatter(backend *cache.RepoCache) error {
 	return nil
 }
 
+func userLsOrgmodeFormatter(backend *cache.RepoCache) error {
+	for _, id := range backend.AllIdentityIds() {
+		i, err := backend.ResolveIdentityExcerpt(id)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("* %s %s\n",
+			i.Id.Human(),
+			i.DisplayName(),
+		)
+	}
+
+	return nil
+}
+
 var userLsCmd = &cobra.Command{
 	Use:     "ls",
 	Short:   "List identities.",
@@ -104,5 +122,5 @@ func init() {
 	userCmd.AddCommand(userLsCmd)
 	userLsCmd.Flags().SortFlags = false
 	userLsCmd.Flags().StringVarP(&userLsOutputFormat, "format", "f", "default",
-		"Select the output formatting style. Valid values are [default,plain,json]")
+		"Select the output formatting style. Valid values are [default,plain,json,org-mode]")
 }

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -1,15 +1,19 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"github.com/MichaelMure/git-bug/cache"
 	"github.com/MichaelMure/git-bug/util/colors"
 	"github.com/MichaelMure/git-bug/util/interrupt"
 	"github.com/spf13/cobra"
 )
 
-func runUserLs(cmd *cobra.Command, args []string) error {
+var (
+	userLsOutputFormat string
+)
+
+func runUserLs(_ *cobra.Command, _ []string) error {
 	backend, err := cache.NewRepoCache(repo)
 	if err != nil {
 		return err
@@ -17,6 +21,42 @@ func runUserLs(cmd *cobra.Command, args []string) error {
 	defer backend.Close()
 	interrupt.RegisterCleaner(backend.Close)
 
+	switch userLsOutputFormat {
+	case "json":
+		return userLsJsonFormatter(backend)
+	case "plain":
+		return userLsPlainFormatter(backend)
+	case "default":
+		return userLsDefaultFormatter(backend)
+	default:
+		return fmt.Errorf("unknown format %s", userLsOutputFormat)
+	}
+}
+
+type JSONIdentity struct {
+	Id      string `json:"id"`
+	HumanId string `json:"human_id"`
+	Name    string `json:"name"`
+	Login   string `json:"login"`
+}
+
+func userLsPlainFormatter(backend *cache.RepoCache) error {
+	for _, id := range backend.AllIdentityIds() {
+		i, err := backend.ResolveIdentityExcerpt(id)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s %s\n",
+			i.Id.Human(),
+			i.DisplayName(),
+		)
+	}
+
+	return nil
+}
+
+func userLsDefaultFormatter(backend *cache.RepoCache) error {
 	for _, id := range backend.AllIdentityIds() {
 		i, err := backend.ResolveIdentityExcerpt(id)
 		if err != nil {
@@ -32,6 +72,27 @@ func runUserLs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func userLsJsonFormatter(backend *cache.RepoCache) error {
+	users := []JSONIdentity{}
+	for _, id := range backend.AllIdentityIds() {
+		i, err := backend.ResolveIdentityExcerpt(id)
+		if err != nil {
+			return err
+		}
+
+		users = append(users, JSONIdentity{
+			i.Id.String(),
+			i.Id.Human(),
+			i.Name,
+			i.Login,
+		})
+	}
+
+	jsonObject, _ := json.MarshalIndent(users, "", "    ")
+	fmt.Printf("%s\n", jsonObject)
+	return nil
+}
+
 var userLsCmd = &cobra.Command{
 	Use:     "ls",
 	Short:   "List identities.",
@@ -42,4 +103,6 @@ var userLsCmd = &cobra.Command{
 func init() {
 	userCmd.AddCommand(userLsCmd)
 	userLsCmd.Flags().SortFlags = false
+	userLsCmd.Flags().StringVarP(&userLsOutputFormat, "format", "f", "default",
+		"Select the output formatting style. Valid values are [default,plain,json]")
 }

--- a/doc/man/git-bug-ls.1
+++ b/doc/man/git-bug-ls.1
@@ -59,7 +59,7 @@ You can pass an additional query to filter and order the list. This query can be
 
 .PP
 \fB\-f\fP, \fB\-\-format\fP="default"
-	Select the output formatting style. Valid values are [default, plain(text), json]
+	Select the output formatting style. Valid values are [default,plain,json,org\-mode]
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]

--- a/doc/man/git-bug-show.1
+++ b/doc/man/git-bug-show.1
@@ -19,8 +19,12 @@ Display the details of a bug.
 
 .SH OPTIONS
 .PP
-\fB\-f\fP, \fB\-\-field\fP=""
-	Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]
+\fB\-\-field\fP=""
+	Select field to display. Valid values are [author,authorEmail,createTime,lastEdit,humanId,id,labels,shortId,status,title,actors,participants]
+
+.PP
+\fB\-f\fP, \fB\-\-format\fP="default"
+	Select the output formatting style. Valid values are [default,json,org\-mode]
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]

--- a/doc/man/git-bug-user-ls.1
+++ b/doc/man/git-bug-user-ls.1
@@ -19,6 +19,10 @@ List identities.
 
 .SH OPTIONS
 .PP
+\fB\-f\fP, \fB\-\-format\fP="default"
+	Select the output formatting style. Valid values are [default,json]
+
+.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
 	help for ls
 

--- a/doc/md/git-bug_ls.md
+++ b/doc/md/git-bug_ls.md
@@ -35,7 +35,7 @@ git bug ls --status closed --by creation
   -n, --no strings            Filter by absence of something. Valid values are [label]
   -b, --by string             Sort the results by a characteristic. Valid values are [id,creation,edit] (default "creation")
   -d, --direction string      Select the sorting direction. Valid values are [asc,desc] (default "asc")
-  -f, --format string         Select the output formatting style. Valid values are [default, plain(text), json] (default "default")
+  -f, --format string         Select the output formatting style. Valid values are [default,plain,json,org-mode] (default "default")
   -h, --help                  help for ls
 ```
 

--- a/doc/md/git-bug_show.md
+++ b/doc/md/git-bug_show.md
@@ -13,8 +13,9 @@ git-bug show [<id>] [flags]
 ### Options
 
 ```
-  -f, --field string   Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]
-  -h, --help           help for show
+      --field string    Select field to display. Valid values are [author,authorEmail,createTime,lastEdit,humanId,id,labels,shortId,status,title,actors,participants]
+  -f, --format string   Select the output formatting style. Valid values are [default,json,org-mode] (default "default")
+  -h, --help            help for show
 ```
 
 ### SEE ALSO

--- a/doc/md/git-bug_user_ls.md
+++ b/doc/md/git-bug_user_ls.md
@@ -13,7 +13,8 @@ git-bug user ls [flags]
 ### Options
 
 ```
-  -h, --help   help for ls
+  -f, --format string   Select the output formatting style. Valid values are [default,json] (default "default")
+  -h, --help            help for ls
 ```
 
 ### SEE ALSO

--- a/graphql/models/lazy_bug.go
+++ b/graphql/models/lazy_bug.go
@@ -81,7 +81,7 @@ func (lb *lazyBug) Id() entity.Id {
 }
 
 func (lb *lazyBug) LastEdit() time.Time {
-	return time.Unix(lb.excerpt.EditUnixTime, 0)
+	return lb.excerpt.EditTime()
 }
 
 func (lb *lazyBug) Status() bug.Status {
@@ -133,7 +133,7 @@ func (lb *lazyBug) Participants() ([]IdentityWrapper, error) {
 }
 
 func (lb *lazyBug) CreatedAt() time.Time {
-	return time.Unix(lb.excerpt.CreateUnixTime, 0)
+	return lb.excerpt.CreateTime()
 }
 
 func (lb *lazyBug) Timeline() ([]bug.TimelineItem, error) {
@@ -163,7 +163,7 @@ func NewLoadedBug(snap *bug.Snapshot) *loadedBug {
 }
 
 func (l *loadedBug) LastEdit() time.Time {
-	return l.Snapshot.LastEditTime()
+	return l.Snapshot.EditTime()
 }
 
 func (l *loadedBug) Status() bug.Status {
@@ -203,7 +203,7 @@ func (l *loadedBug) Participants() ([]IdentityWrapper, error) {
 }
 
 func (l *loadedBug) CreatedAt() time.Time {
-	return l.Snapshot.CreatedAt
+	return l.Snapshot.CreateTime
 }
 
 func (l *loadedBug) Timeline() ([]bug.TimelineItem, error) {

--- a/misc/bash_completion/git-bug
+++ b/misc/bash_completion/git-bug
@@ -933,8 +933,11 @@ _git-bug_show()
 
     flags+=("--field=")
     two_word_flags+=("--field")
-    two_word_flags+=("-f")
     local_nonpersistent_flags+=("--field=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
 
     must_have_one_flag=()
     must_have_one_noun=()
@@ -1122,6 +1125,10 @@ _git-bug_user_ls()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/misc/powershell_completion/git-bug
+++ b/misc/powershell_completion/git-bug
@@ -159,8 +159,8 @@ Register-ArgumentCompleter -Native -CommandName 'git-bug' -ScriptBlock {
             [CompletionResult]::new('--by', 'by', [CompletionResultType]::ParameterName, 'Sort the results by a characteristic. Valid values are [id,creation,edit]')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Select the sorting direction. Valid values are [asc,desc]')
             [CompletionResult]::new('--direction', 'direction', [CompletionResultType]::ParameterName, 'Select the sorting direction. Valid values are [asc,desc]')
-            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default, plain(text), json]')
-            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default, plain(text), json]')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,plain,json,org-mode]')
+            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,plain,json,org-mode]')
             break
         }
         'git-bug;ls-id' {
@@ -179,8 +179,9 @@ Register-ArgumentCompleter -Native -CommandName 'git-bug' -ScriptBlock {
             break
         }
         'git-bug;show' {
-            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]')
-            [CompletionResult]::new('--field', 'field', [CompletionResultType]::ParameterName, 'Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]')
+            [CompletionResult]::new('--field', 'field', [CompletionResultType]::ParameterName, 'Select field to display. Valid values are [author,authorEmail,createTime,lastEdit,humanId,id,labels,shortId,status,title,actors,participants]')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,json,org-mode]')
+            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,json,org-mode]')
             break
         }
         'git-bug;status' {
@@ -221,6 +222,8 @@ Register-ArgumentCompleter -Native -CommandName 'git-bug' -ScriptBlock {
             break
         }
         'git-bug;user;ls' {
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,json]')
+            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'Select the output formatting style. Valid values are [default,json]')
             break
         }
         'git-bug;version' {

--- a/misc/zsh_completion/git-bug
+++ b/misc/zsh_completion/git-bug
@@ -304,7 +304,7 @@ function _git-bug_ls {
     '(*-n *--no)'{\*-n,\*--no}'[Filter by absence of something. Valid values are [label]]:' \
     '(-b --by)'{-b,--by}'[Sort the results by a characteristic. Valid values are [id,creation,edit]]:' \
     '(-d --direction)'{-d,--direction}'[Select the sorting direction. Valid values are [asc,desc]]:' \
-    '(-f --format)'{-f,--format}'[Select the output formatting style. Valid values are [default, plain(text), json]]:'
+    '(-f --format)'{-f,--format}'[Select the output formatting style. Valid values are [default,plain,json,org-mode]]:'
 }
 
 function _git-bug_ls-id {
@@ -329,7 +329,8 @@ function _git-bug_select {
 
 function _git-bug_show {
   _arguments \
-    '(-f --field)'{-f,--field}'[Select field to display. Valid values are [author,authorEmail,createTime,humanId,id,labels,shortId,status,title,actors,participants]]:'
+    '--field[Select field to display. Valid values are [author,authorEmail,createTime,lastEdit,humanId,id,labels,shortId,status,title,actors,participants]]:' \
+    '(-f --format)'{-f,--format}'[Select the output formatting style. Valid values are [default,json,org-mode]]:'
 }
 
 
@@ -443,7 +444,8 @@ function _git-bug_user_create {
 }
 
 function _git-bug_user_ls {
-  _arguments
+  _arguments \
+    '(-f --format)'{-f,--format}'[Select the output formatting style. Valid values are [default,json]]:'
 }
 
 function _git-bug_version {

--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/MichaelMure/go-term-text"
 	"github.com/awesome-gocui/gocui"
@@ -315,7 +314,7 @@ func (bt *bugTable) render(v *gocui.View, maxX int) {
 			authorDisplayName = excerpt.LegacyAuthor.DisplayName()
 		}
 
-		lastEditTime := time.Unix(excerpt.EditUnixTime, 0)
+		lastEditTime := excerpt.EditTime()
 
 		id := text.LeftPadMaxLine(excerpt.Id.Human(), columnWidths["id"], 1)
 		status := text.LeftPadMaxLine(excerpt.Status.String(), columnWidths["status"], 1)

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -219,7 +219,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 		colors.Bold(snap.Title),
 		colors.Yellow(snap.Status),
 		colors.Magenta(snap.Author.DisplayName()),
-		snap.CreatedAt.Format(timeLayout),
+		snap.CreateTime.Format(timeLayout),
 		edited,
 	)
 	bugHeader, lines := text.Wrap(bugHeader, maxX)


### PR DESCRIPTION
This PR adds flags to the mentioned commands which allow the user to specify what output format they would like the commands to output in.

In addition, this adds support for a new output flag: `org-mode`, a format used by emacs users. Hopefully, this improves the functionality of the commands.

Example org-mode outputs:
- ls:
```
* 04174ef Open [2020-05-23 18:01:27 +0800 CST] karlicoss (karlicoss): [https://github.com/MichaelMure/git-bug/issues/392][feature: ls dump issues as plaintext (markdown/org-mode)] :[CLI:bridge:enhancement]:
** Last Edited: 2020-06-18 19:59:59 +0800 CST
** Actors:
: 528f341 karlicoss (karlicoss)
: 571aa44 Michael Muré (MichaelMure)
: ff7d2b9 vince
** Participants:
: 528f341 karlicoss (karlicoss)
: 571aa44 Michael Muré (MichaelMure)
: ff7d2b9 vince
```

- show:
```
04174ef [open] feature: ls dump issues as plaintext (markdown/org-mode)
* Author: karlicoss (karlicoss)
* Creation Time: 2020-05-23 18:01:27 +0800 CST
* Last Edit: 2020-06-18 19:59:59 +0800 CST
* Labels:
** CLI
** bridge
** enhancement
* Actors: 
** 528f341 karlicoss (karlicoss)
** 571aa44 Michael Muré (MichaelMure)
** ff7d2b9 vince
* Participants:
** 528f341 karlicoss (karlicoss)
** 571aa44 Michael Muré (MichaelMure)
** ff7d2b9 vince
* Comments:
** #0 karlicoss (karlicoss)
: Basically a command like `git bug dump` that would dump the issues rendered as a single markdown/org-mode file (or a directory of files). This would allow to instantly search in issu
es within the IDE without having to switch to the terminal/web UI.
** #1 Michael Muré (MichaelMure)
: Hoooo, I like this idea of org-mode. I'm not so familiar with it though, could you provide an example with all kind of relevant features ?
:
: Yes, git-bug would benefit from having this kind of export. It has been touched on in #45 and #370.
...
```

- user ls:
```
* 8eec8d4 Glendon Solsberry (gms8994)
* 6310f3a Martin Delille (MartinDelille)
* 92e0130 Alexandre Franke (afranke)
* 23f2a2e Anachron (Anachron)
* 9ddf4dc Tanguy ⧓ Herrmann (dolanor)
* 875fbde Vincent Ambo (tazjin)
* 677a5b5 George Antoniadis (geoah)
```