### PR TITLE
Trim titles in list views

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -210,7 +210,7 @@ func lsDefaultFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 
 		// truncate + pad if needed
 		labelsFmt := text.TruncateMax(labelsTxt.String(), 10)
-		titleFmt := text.LeftPadMaxLine(b.Title, 50-text.Len(labelsFmt), 0)
+		titleFmt := text.LeftPadMaxLine(strings.TrimSpace(b.Title), 50-text.Len(labelsFmt), 0)
 		authorFmt := text.LeftPadMaxLine(name, 15, 0)
 
 		comments := fmt.Sprintf("%4d 💬", b.LenComments)
@@ -231,7 +231,7 @@ func lsDefaultFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 
 func lsPlainFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 	for _, b := range bugExcerpts {
-		env.out.Printf("%s [%s] %s\n", b.Id.Human(), b.Status, b.Title)
+		env.out.Printf("%s [%s] %s\n", b.Id.Human(), b.Status, strings.TrimSpace(b.Title))
 	}
 	return nil
 }

--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -319,7 +319,7 @@ func (bt *bugTable) render(v *gocui.View, maxX int) {
 		id := text.LeftPadMaxLine(excerpt.Id.Human(), columnWidths["id"], 1)
 		status := text.LeftPadMaxLine(excerpt.Status.String(), columnWidths["status"], 1)
 		labels := text.TruncateMax(labelsTxt.String(), minInt(columnWidths["title"]-2, 10))
-		title := text.LeftPadMaxLine(excerpt.Title, columnWidths["title"]-text.Len(labels), 1)
+		title := text.LeftPadMaxLine(strings.TrimSpace(excerpt.Title), columnWidths["title"]-text.Len(labels), 1)
 		author := text.LeftPadMaxLine(authorDisplayName, columnWidths["author"], 1)
 		comments := text.LeftPadMaxLine(summaryTxt, columnWidths["comments"], 1)
 		lastEdit := text.LeftPadMaxLine(humanize.Time(lastEditTime), columnWidths["lastEdit"], 1)


### PR DESCRIPTION
I've been working on a GH repository which includes a lot of leading whitespace in issues due to a template including it.

I think the bug data shouldn't be altered, but it still makes sense to strip titles in list/table views so that more of the bug title is readily visible. The WebUI probably does that implicitly, while I'm unsure about other modes.