### PR TITLE
Set the Fg color of the status bar to White

### DIFF
--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -116,6 +116,7 @@ func (bt *bugTable) layout(g *gocui.Gui) error {
 		}
 
 		v.Frame = false
+		v.FgColor = gocui.ColorWhite
 		v.BgColor = gocui.ColorBlue
 
 		_, _ = fmt.Fprintf(v, "[q] Quit [s] Search [←↓↑→,hjkl] Navigation [↵] Open bug [n] New bug [i] Pull [o] Push")

--- a/termui/label_select.go
+++ b/termui/label_select.go
@@ -144,6 +144,7 @@ func (ls *labelSelect) layout(g *gocui.Gui) error {
 			return err
 		}
 		v.Frame = false
+		v.FgColor = gocui.ColorWhite
 		v.BgColor = gocui.ColorBlue
 	}
 	v.Clear()

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -92,6 +92,7 @@ func (sb *showBug) layout(g *gocui.Gui) error {
 
 		sb.childViews = append(sb.childViews, showBugInstructionView)
 		v.Frame = false
+		v.FgColor = gocui.ColorWhite
 		v.BgColor = gocui.ColorBlue
 	}
 


### PR DESCRIPTION
Always set the Fg color when Bg is set. This fixes poor contrast on
terminals with non-standard foreground colors.