### PR TITLE
Add the 'rm' command

### DIFF
--- a/bug/bug.go
+++ b/bug/bug.go
@@ -243,15 +243,18 @@ func readBug(repo repository.ClockedRepo, ref string) (*Bug, error) {
 }
 
 // RemoveLocalBug will remove a local bug from its hash
-func RemoveLocalBug(repo repository.ClockedRepo, id entity.Id) error {
-	ref := bugsRefPattern + id.String()
-	return repo.RemoveRef(ref)
-}
-
-// RemoveRemoteBug will remove a remote bug locally from its hash
-func RemoveRemoteBug(repo repository.ClockedRepo, remote string, id entity.Id) error {
-	ref := fmt.Sprintf(bugsRemoteRefPattern, remote) + id.String()
-	return repo.RemoveRef(ref)
+func RemoveBug(repo repository.ClockedRepo, id entity.Id) error {
+	refs, err := repo.ListRefs(id.String())
+	if err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		err = repo.RemoveRef(ref)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type StreamedBug struct {

--- a/bug/bug.go
+++ b/bug/bug.go
@@ -242,8 +242,15 @@ func readBug(repo repository.ClockedRepo, ref string) (*Bug, error) {
 	return &bug, nil
 }
 
+// RemoveLocalBug will remove a local bug from its hash
 func RemoveLocalBug(repo repository.ClockedRepo, id entity.Id) error {
 	ref := bugsRefPattern + id.String()
+	return repo.RemoveRef(ref)
+}
+
+// RemoveRemoteBug will remove a remote bug locally from its hash
+func RemoveRemoteBug(repo repository.ClockedRepo, remote string, id entity.Id) error {
+	ref := fmt.Sprintf(bugsRemoteRefPattern, remote) + id.String()
 	return repo.RemoveRef(ref)
 }
 

--- a/bug/bug_test.go
+++ b/bug/bug_test.go
@@ -171,4 +171,8 @@ func TestBugRemove(t *testing.T) {
 
 	_, err = ReadRemoteBug(repo, "remoteB", b.Id())
 	require.Error(t, ErrBugNotExist, err)
+
+	ids, err := ListLocalIds(repo)
+	require.NoError(t, err)
+	require.Len(t, ids, 100)
 }

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -361,23 +361,14 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 }
 
 // RemoveBug removes a bug from the cache and repo
-// args[0] specifies the bug prefix to remove
-// args[1] (if present) specifies the remote the bug was imported from
-func (c *RepoCache) RemoveBug(prefix string, remote string) error {
+func (c *RepoCache) RemoveBug(prefix string) error {
 	b, err := c.ResolveBugPrefix(prefix)
 
 	if err != nil {
 		return err
 	}
 
-	if remote == "" {
-		err = bug.RemoveLocalBug(c.repo, b.Id())
-	} else {
-		err = bug.RemoveRemoteBug(c.repo, remote, b.Id())
-	}
-	if err != nil {
-		return err
-	}
+	err = bug.RemoveBug(c.repo, b.Id())
 
 	delete(c.bugs, b.Id())
 	delete(c.bugExcerpts, b.Id())

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -361,13 +361,24 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 }
 
 // RemoveBug removes a bug from the cache and repo
-func (c *RepoCache) RemoveBug(prefix string) error {
-	b, err := c.ResolveBugPrefix(prefix)
+// args[0] specifies the bug prefix to remove
+// args[1] (if present) specifies the remote the bug was imported from
+func (c *RepoCache) RemoveBug(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("you must provide a bug prefix to remove")
+	}
+
+	b, err := c.ResolveBugPrefix(args[0])
+
 	if err != nil {
 		return err
 	}
 
-	err = bug.RemoveLocalBug(c.repo, b.Id())
+	if len(args) == 1 {
+		err = bug.RemoveLocalBug(c.repo, b.Id())
+	} else {
+		err = bug.RemoveRemoteBug(c.repo, args[1], b.Id())
+	}
 	if err != nil {
 		return err
 	}

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -359,3 +359,21 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 
 	return cached, op, nil
 }
+
+// RemoveBug removes a bug from the cache and repo
+func (c *RepoCache) RemoveBug(prefix string) error {
+	b, err := c.ResolveBugPrefix(prefix)
+	if err != nil {
+		return err
+	}
+
+	err = bug.RemoveLocalBug(c.repo, b.Id())
+	if err != nil {
+		return err
+	}
+
+	delete(c.bugs, b.Id())
+	delete(c.bugExcerpts, b.Id())
+
+	return c.writeBugCache()
+}

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -363,21 +363,17 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 // RemoveBug removes a bug from the cache and repo
 // args[0] specifies the bug prefix to remove
 // args[1] (if present) specifies the remote the bug was imported from
-func (c *RepoCache) RemoveBug(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("you must provide a bug prefix to remove")
-	}
-
-	b, err := c.ResolveBugPrefix(args[0])
+func (c *RepoCache) RemoveBug(prefix string, remote string) error {
+	b, err := c.ResolveBugPrefix(prefix)
 
 	if err != nil {
 		return err
 	}
 
-	if len(args) == 1 {
+	if remote == "" {
 		err = bug.RemoveLocalBug(c.repo, b.Id())
 	} else {
-		err = bug.RemoveRemoteBug(c.repo, args[1], b.Id())
+		err = bug.RemoveRemoteBug(c.repo, remote, b.Id())
 	}
 	if err != nil {
 		return err

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -360,7 +360,7 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 	return cached, op, nil
 }
 
-// RemoveBug removes a bug from the cache and repo
+// RemoveBug removes a bug from the cache and repo given a bug id prefix
 func (c *RepoCache) RemoveBug(prefix string) error {
 	b, err := c.ResolveBugPrefix(prefix)
 

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -103,7 +103,7 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Possible to delete a bug
-	err = cache.RemoveBug([]string{bug1.Id().Human()})
+	err = cache.RemoveBug(bug1.Id().Human(), "")
 	require.NoError(t, err)
 	require.Equal(t, len(cache.AllBugsIds()), 1)
 }

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/MichaelMure/git-bug/bug"
 	"github.com/MichaelMure/git-bug/query"
 	"github.com/MichaelMure/git-bug/repository"
 )
@@ -204,4 +205,8 @@ func TestRemove(t *testing.T) {
 	err = repoCache.RemoveBug(b1.Id().String())
 	require.NoError(t, err)
 	assert.Equal(t, 100, len(repoCache.bugs))
+	assert.Equal(t, 100, len(repoCache.bugExcerpts))
+
+	_, err = repoCache.ResolveBug(b1.Id())
+	assert.Error(t, bug.ErrBugNotExist, err)
 }

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -101,6 +101,11 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.ResolveBugPrefix(bug1.Id().String()[:10])
 	require.NoError(t, err)
+
+	// Possible to delete a bug
+	err = cache.RemoveBug([]string{bug1.Id().Human()})
+	require.NoError(t, err)
+	require.Equal(t, len(cache.AllBugsIds()), 1)
 }
 
 func TestPushPull(t *testing.T) {

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -10,7 +10,7 @@ func newRmCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:      "rm <id> [<remote>]",
+		Use:      "rm <id>",
 		Short:    "Remove an existing bug.",
 		Long:     "Remove an existing bug in the local repository. If the bug was imported from a bridge, specify the remote name to remove it from. Note removing bugs that were imported from bridges will not remove the bug remote, and will only remove the local copy of the bug.",
 		PreRunE:  loadBackendEnsureUser(env),
@@ -27,15 +27,11 @@ func newRmCommand() *cobra.Command {
 }
 
 func runRm(env *Env, args []string) (err error) {
-	switch len(args) {
-	case 1:
-		err = env.backend.RemoveBug(args[0], "")
-		break
-	case 2:
-		err = env.backend.RemoveBug(args[0], args[1])
-	default:
-		return errors.New("invalid number of arguments for rm command")
+	if len(args) == 0 {
+		return errors.New("you must provide a bug prefix to remove")
 	}
+
+	err = env.backend.RemoveBug(args[0])
 
 	if err != nil {
 		return

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -1,25 +1,20 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
-type rmOptions struct {
-}
-
 func newRmCommand() *cobra.Command {
 	env := newEnv()
-	options := rmOptions{}
 
 	cmd := &cobra.Command{
-		Use:      "rm <id>",
+		Use:      "rm <id> [<remote>]",
 		Short:    "Remove an existing bug.",
+		Long:     "Remove an existing bug in the local repository. If the bug was imported from a bridge, specify the remote name to remove it from. Note removing bugs that were imported from bridges will not remove the bug remote, and will only remove the local copy of the bug.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRm(env, options, args)
+			return runRm(env, args)
 		},
 	}
 
@@ -29,17 +24,14 @@ func newRmCommand() *cobra.Command {
 	return cmd
 }
 
-func runRm(env *Env, opts rmOptions, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("you must provide a bug id prefix to remove")
-	}
+func runRm(env *Env, args []string) (err error) {
+	err = env.backend.RemoveBug(args)
 
-	err := env.backend.RemoveBug(args[0])
 	if err != nil {
-		return err
+		return
 	}
 
 	env.out.Printf("bug %s removed\n", args[0])
 
-	return nil
+	return
 }

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -12,7 +12,7 @@ func newRmCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:      "rm <id>",
 		Short:    "Remove an existing bug.",
-		Long:     "Remove an existing bug in the local repository. If the bug was imported from a bridge, specify the remote name to remove it from. Note removing bugs that were imported from bridges will not remove the bug remote, and will only remove the local copy of the bug.",
+		Long:     "Remove an existing bug in the local repository. Note removing bugs that were imported from bridges will not remove the bug on the remote, and will only remove the local copy of the bug.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type rmOptions struct {
+}
+
+func newRmCommand() *cobra.Command {
+	env := newEnv()
+	options := rmOptions{}
+
+	cmd := &cobra.Command{
+		Use:      "rm <id>",
+		Short:    "Remove an existing bug.",
+		PreRunE:  loadBackendEnsureUser(env),
+		PostRunE: closeBackend(env),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRm(env, options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+
+	return cmd
+}
+
+func runRm(env *Env, opts rmOptions, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("you must provide a bug id prefix to remove")
+	}
+
+	err := env.backend.RemoveBug(args[0])
+	if err != nil {
+		return err
+	}
+
+	env.out.Printf("bug %s removed\n", args[0])
+
+	return nil
+}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +27,15 @@ func newRmCommand() *cobra.Command {
 }
 
 func runRm(env *Env, args []string) (err error) {
-	err = env.backend.RemoveBug(args)
+	switch len(args) {
+	case 1:
+		err = env.backend.RemoveBug(args[0], "")
+		break
+	case 2:
+		err = env.backend.RemoveBug(args[0], args[1])
+	default:
+		return errors.New("invalid number of arguments for rm command")
+	}
 
 	if err != nil {
 		return

--- a/commands/root.go
+++ b/commands/root.go
@@ -71,6 +71,7 @@ _git_bug() {
 	cmd.AddCommand(newLsLabelCommand())
 	cmd.AddCommand(newPullCommand())
 	cmd.AddCommand(newPushCommand())
+	cmd.AddCommand(newRmCommand())
 	cmd.AddCommand(newSelectCommand())
 	cmd.AddCommand(newShowCommand())
 	cmd.AddCommand(newStatusCommand())


### PR DESCRIPTION
This PR adds a rm command, with usage `rm <id> [<remote>]`.  
This will remove a bug locally by its bug prefix and, if specified, the name of the remote it was imported from, addressing #66.
Note this does not support removing remote bugs, as pushing deletes is not recommended. In the future, if a feature is added to selectively import remote bugs, perhaps that issue can be addressed there.
