### PR TITLE
LRU Cache

### DIFF
--- a/bug/bug.go
+++ b/bug/bug.go
@@ -749,22 +749,3 @@ func (bug *Bug) Compile() Snapshot {
 
 	return snap
 }
-
-// EquivalentBug returns true if two bugs are equal
-func EquivalentBug(expected, actual *Bug) bool {
-	if len(expected.packs) != len(actual.packs) {
-		return false
-	}
-
-	for i := range expected.packs {
-		for j := range expected.packs[i].Operations {
-			actual.packs[i].Operations[j].base().id = expected.packs[i].Operations[j].base().id
-		}
-	}
-
-	if expected != actual {
-		return false
-	}
-
-	return true
-}

--- a/bug/bug.go
+++ b/bug/bug.go
@@ -749,3 +749,22 @@ func (bug *Bug) Compile() Snapshot {
 
 	return snap
 }
+
+// EquivalentBug returns true if two bugs are equal
+func EquivalentBug(expected, actual *Bug) bool {
+	if len(expected.packs) != len(actual.packs) {
+		return false
+	}
+
+	for i := range expected.packs {
+		for j := range expected.packs[i].Operations {
+			actual.packs[i].Operations[j].base().id = expected.packs[i].Operations[j].base().id
+		}
+	}
+
+	if expected != actual {
+		return false
+	}
+
+	return true
+}

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -37,8 +37,6 @@ func (c *BugCache) Snapshot() *bug.Snapshot {
 }
 
 func (c *BugCache) Id() entity.Id {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 	return c.bug.Id()
 }
 

--- a/cache/lru_id_cache.go
+++ b/cache/lru_id_cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"math"
+
 	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/MichaelMure/git-bug/entity"
@@ -8,16 +10,14 @@ import (
 
 type LRUIdCache struct {
 	parentCache *lru.Cache
-	maxSize     int
 }
 
-func NewLRUIdCache(size int) *LRUIdCache {
+func NewLRUIdCache() *LRUIdCache {
 	// Ignore error here
-	cache, _ := lru.New(size)
+	cache, _ := lru.New(math.MaxInt32)
 
 	return &LRUIdCache{
 		cache,
-		size,
 	}
 }
 
@@ -39,7 +39,7 @@ func (c *LRUIdCache) GetOldest() (entity.Id, bool) {
 	return id.(entity.Id), present
 }
 
-func (c *LRUIdCache) GetAll() (ids []entity.Id) {
+func (c *LRUIdCache) GetOldestToNewest() (ids []entity.Id) {
 	interfaceKeys := c.parentCache.Keys()
 	for _, id := range interfaceKeys {
 		ids = append(ids, id.(entity.Id))
@@ -53,9 +53,4 @@ func (c *LRUIdCache) Len() int {
 
 func (c *LRUIdCache) Remove(id entity.Id) bool {
 	return c.parentCache.Remove(id)
-}
-
-func (c *LRUIdCache) Resize(size int) int {
-	c.maxSize = size
-	return c.parentCache.Resize(size)
 }

--- a/cache/lru_id_cache.go
+++ b/cache/lru_id_cache.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	lru "github.com/hashicorp/golang-lru"
+
+	"github.com/MichaelMure/git-bug/entity"
+)
+
+type LRUIdCache struct {
+	parentCache *lru.Cache
+	maxSize     int
+	onEvict     func(id entity.Id)
+}
+
+func NewLRUIdCache(size int, onEvicted func(id entity.Id)) (*LRUIdCache, error) {
+	cache, err := lru.New(size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LRUIdCache{
+		cache,
+		size,
+		onEvicted,
+	}, nil
+}
+
+func (c *LRUIdCache) Add(id entity.Id) bool {
+	return c.parentCache.Add(id, nil)
+}
+
+func (c *LRUIdCache) Contains(id entity.Id) bool {
+	return c.parentCache.Contains(id)
+}
+
+func (c *LRUIdCache) Get(id entity.Id) bool {
+	_, present := c.parentCache.Get(id)
+	return present
+}
+
+func (c *LRUIdCache) GetOldest() (entity.Id, bool) {
+	id, _, present := c.parentCache.GetOldest()
+	return id.(entity.Id), present
+}
+
+func (c *LRUIdCache) GetAll() (ids []entity.Id) {
+	interfaceKeys := c.parentCache.Keys()
+	for _, id := range interfaceKeys {
+		ids = append(ids, id.(entity.Id))
+	}
+	return
+}
+
+func (c *LRUIdCache) Len() int {
+	return c.parentCache.Len()
+}
+
+func (c *LRUIdCache) Remove(id entity.Id) bool {
+	return c.parentCache.Remove(id)
+}
+
+func (c *LRUIdCache) Resize(size int) int {
+	return c.parentCache.Resize(size)
+}

--- a/cache/lru_id_cache.go
+++ b/cache/lru_id_cache.go
@@ -9,20 +9,16 @@ import (
 type LRUIdCache struct {
 	parentCache *lru.Cache
 	maxSize     int
-	onEvict     func(id entity.Id)
 }
 
-func NewLRUIdCache(size int, onEvicted func(id entity.Id)) (*LRUIdCache, error) {
-	cache, err := lru.New(size)
-	if err != nil {
-		return nil, err
-	}
+func NewLRUIdCache(size int) *LRUIdCache {
+	// Ignore error here
+	cache, _ := lru.New(size)
 
 	return &LRUIdCache{
 		cache,
 		size,
-		onEvicted,
-	}, nil
+	}
 }
 
 func (c *LRUIdCache) Add(id entity.Id) bool {
@@ -60,5 +56,6 @@ func (c *LRUIdCache) Remove(id entity.Id) bool {
 }
 
 func (c *LRUIdCache) Resize(size int) int {
+	c.maxSize = size
 	return c.parentCache.Resize(size)
 }

--- a/cache/lru_id_cache.go
+++ b/cache/lru_id_cache.go
@@ -13,7 +13,7 @@ type LRUIdCache struct {
 }
 
 func NewLRUIdCache() *LRUIdCache {
-	// Ignore error here
+	// we can ignore the error here as it would only fail if the size is negative.
 	cache, _ := lru.New(math.MaxInt32)
 
 	return &LRUIdCache{

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -22,7 +22,7 @@ import (
 const formatVersion = 2
 
 // The maximum number of bugs loaded in memory. After that, eviction will be done.
-const defaultMaxLoadedBugs = 100
+const defaultMaxLoadedBugs = 1000
 
 var _ repository.RepoCommon = &RepoCache{}
 
@@ -160,7 +160,7 @@ func (c *RepoCache) Close() error {
 
 	c.identities = make(map[entity.Id]*IdentityCache)
 	c.identitiesExcerpts = nil
-	c.bugs = nil
+	c.bugs = make(map[entity.Id]*BugCache)
 	c.bugExcerpts = nil
 
 	lockPath := repoLockFilePath(c.repo)

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -21,7 +21,8 @@ import (
 // 2: added cache for identities with a reference in the bug cache
 const formatVersion = 2
 
-const lruCacheSize = 100
+// The maximum number of bugs loaded in memory. After that, eviction will be done.
+const defaultMaxLoadedBugs = 100
 
 var _ repository.RepoCommon = &RepoCache{}
 
@@ -46,14 +47,16 @@ type RepoCache struct {
 	// the name of the repository, as defined in the MultiRepoCache
 	name string
 
+	// maximum number of loaded bugs
+	maxLoadedBugs int
+
 	muBug sync.RWMutex
 	// excerpt of bugs data for all bugs
 	bugExcerpts map[entity.Id]*BugExcerpt
 	// bug loaded in memory
 	bugs map[entity.Id]*BugCache
-
-	// presentBugs is an LRU cache that records which bugs the cache has loaded in
-	presentBugs *LRUIdCache
+	// loadedBugs is an LRU cache that records which bugs the cache has loaded in
+	loadedBugs *LRUIdCache
 
 	muIdentity sync.RWMutex
 	// excerpt of identities data for all identities
@@ -71,19 +74,18 @@ func NewRepoCache(r repository.ClockedRepo) (*RepoCache, error) {
 
 func NewNamedRepoCache(r repository.ClockedRepo, name string) (*RepoCache, error) {
 	c := &RepoCache{
-		repo:       r,
-		name:       name,
-		bugs:       make(map[entity.Id]*BugCache),
-		identities: make(map[entity.Id]*IdentityCache),
+		repo:          r,
+		name:          name,
+		maxLoadedBugs: defaultMaxLoadedBugs,
+		bugs:          make(map[entity.Id]*BugCache),
+		loadedBugs:    NewLRUIdCache(),
+		identities:    make(map[entity.Id]*IdentityCache),
 	}
 
 	err := c.lock()
 	if err != nil {
 		return &RepoCache{}, err
 	}
-
-	presentBugs := NewLRUIdCache(lruCacheSize)
-	c.presentBugs = presentBugs
 
 	err = c.load()
 	if err == nil {
@@ -97,6 +99,12 @@ func NewNamedRepoCache(r repository.ClockedRepo, name string) (*RepoCache, error
 	}
 
 	return c, c.write()
+}
+
+// setCacheSize change the maximum number of loaded bugs
+func (c *RepoCache) setCacheSize(size int) {
+	c.maxLoadedBugs = size
+	c.evictIfNeeded()
 }
 
 // load will try to read from the disk all the cache files

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -119,7 +119,7 @@ func (c *RepoCache) ResolveBugExcerpt(id entity.Id) (*BugExcerpt, error) {
 
 	excerpt, ok := c.bugExcerpts[id]
 	if !ok {
-		panic("missing bug in the cache")
+		return nil, bug.ErrBugNotExist
 	}
 
 	return excerpt, nil

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -1,9 +1,7 @@
 package cache
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,13 +179,16 @@ func TestRemove(t *testing.T) {
 	rene, err := repoCache.NewIdentity("René Descartes", "rene@descartes.fr")
 	require.NoError(t, err)
 
+	err = repoCache.SetUserIdentity(rene)
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
-		_, _, err := repoCache.NewBugRaw(rene, time.Now().Unix(), "title", fmt.Sprintf("message%v", i), nil, nil)
+		_, _, err := repoCache.NewBug("title", "message")
 		require.NoError(t, err)
 	}
 
 	// and one more for testing
-	b1, _, err := repoCache.NewBugRaw(rene, time.Now().Unix(), "title", "message", nil, nil)
+	b1, _, err := repoCache.NewBug("title", "message")
 	require.NoError(t, err)
 
 	_, err = repoCache.Push("remoteA")
@@ -209,4 +210,71 @@ func TestRemove(t *testing.T) {
 
 	_, err = repoCache.ResolveBug(b1.Id())
 	assert.Error(t, bug.ErrBugNotExist, err)
+}
+
+func TestCacheEviction(t *testing.T) {
+	repo := repository.CreateTestRepo(false)
+	repoCache, err := NewRepoCache(repo)
+	require.NoError(t, err)
+	repoCache.presentBugs.Resize(2)
+
+	require.Equal(t, 0, repoCache.presentBugs.Len())
+	require.Equal(t, 0, len(repoCache.bugs))
+	require.Equal(t, 0, len(repoCache.bugExcerpts))
+
+	// Generating some bugs
+	rene, err := repoCache.NewIdentity("René Descartes", "rene@descartes.fr")
+	require.NoError(t, err)
+	err = repoCache.SetUserIdentity(rene)
+	require.NoError(t, err)
+
+	bug1, _, err := repoCache.NewBug("title", "message")
+	require.NoError(t, err)
+
+	checkBugPresence(t, repoCache, bug1, true)
+	require.Equal(t, 1, repoCache.presentBugs.Len())
+	require.Equal(t, 1, len(repoCache.bugs))
+	require.Equal(t, 1, len(repoCache.bugExcerpts))
+
+	bug2, _, err := repoCache.NewBug("title", "message")
+	require.NoError(t, err)
+
+	checkBugPresence(t, repoCache, bug1, true)
+	checkBugPresence(t, repoCache, bug2, true)
+	require.Equal(t, 2, repoCache.presentBugs.Len())
+	require.Equal(t, 2, len(repoCache.bugs))
+	require.Equal(t, 2, len(repoCache.bugExcerpts))
+
+	// Number of bugs should not exceed max size of lruCache, oldest one should be evicted
+	bug3, _, err := repoCache.NewBug("title", "message")
+	require.NoError(t, err)
+
+	checkBugPresence(t, repoCache, bug1, false)
+	checkBugPresence(t, repoCache, bug2, true)
+	checkBugPresence(t, repoCache, bug3, true)
+	require.Equal(t, 2, repoCache.presentBugs.Len())
+	require.Equal(t, 2, len(repoCache.bugs))
+	require.Equal(t, 2, len(repoCache.bugExcerpts))
+
+	// Accessing bug should update position in lruCache and therefore it should not be evicted
+	repoCache.presentBugs.Get(bug2.Id())
+	oldestId, _ := repoCache.presentBugs.GetOldest()
+	require.Equal(t, bug3.Id(), oldestId)
+
+	checkBugPresence(t, repoCache, bug1, false)
+	checkBugPresence(t, repoCache, bug2, true)
+	checkBugPresence(t, repoCache, bug3, true)
+	require.Equal(t, 2, repoCache.presentBugs.Len())
+	require.Equal(t, 2, len(repoCache.bugs))
+	require.Equal(t, 2, len(repoCache.bugExcerpts))
+}
+
+func checkBugPresence(t *testing.T, cache *RepoCache, bug *BugCache, presence bool) {
+	id := bug.Id()
+	require.Equal(t, presence, cache.presentBugs.Contains(id))
+	b, ok := cache.bugs[id]
+	require.Equal(t, presence, ok)
+	require.Equal(t, bug, b)
+	_, ok = cache.bugExcerpts[id]
+	require.Equal(t, presence, ok)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/gorilla/mux v1.7.4
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
 	github.com/mattn/go-isatty v0.0.12
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=


### PR DESCRIPTION
This PR implements a LRU into the bugCache. It currently has a fixed size of 100 and will automatically evict bugs from the cache if the number of bugs exceeds 100. Note evicting bugs doesn't result in their removal from the repository, just in memory.

Fixes #132