### PR TITLE
cache,bug,identity: structural change

### DIFF
--- a/bug/bug_actions_test.go
+++ b/bug/bug_actions_test.go
@@ -16,6 +16,8 @@ func TestPushPull(t *testing.T) {
 	defer repository.CleanupTestRepos(repoA, repoB, remote)
 
 	reneA := identity.NewIdentity("René Descartes", "rene@descartes.fr")
+	err := reneA.Commit(repoA)
+	require.NoError(t, err)
 
 	bug1, _, err := Create(reneA, time.Now().Unix(), "bug1", "message")
 	require.NoError(t, err)
@@ -37,7 +39,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoB, "origin")
 	require.NoError(t, err)
 
-	bugs := allBugs(t, ReadAllLocalBugs(repoB))
+	bugs := allBugs(t, ReadAllLocal(repoB))
 
 	if len(bugs) != 1 {
 		t.Fatal("Unexpected number of bugs")
@@ -58,7 +60,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	bugs = allBugs(t, ReadAllLocalBugs(repoA))
+	bugs = allBugs(t, ReadAllLocal(repoA))
 
 	if len(bugs) != 2 {
 		t.Fatal("Unexpected number of bugs")
@@ -91,6 +93,8 @@ func _RebaseTheirs(t testing.TB) {
 	defer repository.CleanupTestRepos(repoA, repoB, remote)
 
 	reneA := identity.NewIdentity("René Descartes", "rene@descartes.fr")
+	err := reneA.Commit(repoA)
+	require.NoError(t, err)
 
 	bug1, _, err := Create(reneA, time.Now().Unix(), "bug1", "message")
 	require.NoError(t, err)
@@ -114,7 +118,7 @@ func _RebaseTheirs(t testing.TB) {
 	err = Pull(repoB, "origin")
 	require.NoError(t, err)
 
-	bug2, err := ReadLocalBug(repoB, bug1.Id())
+	bug2, err := ReadLocal(repoB, bug1.Id())
 	require.NoError(t, err)
 	assert.False(t, bug2.NeedCommit())
 
@@ -140,13 +144,13 @@ func _RebaseTheirs(t testing.TB) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	bugs := allBugs(t, ReadAllLocalBugs(repoB))
+	bugs := allBugs(t, ReadAllLocal(repoB))
 
 	if len(bugs) != 1 {
 		t.Fatal("Unexpected number of bugs")
 	}
 
-	bug3, err := ReadLocalBug(repoA, bug1.Id())
+	bug3, err := ReadLocal(repoA, bug1.Id())
 	require.NoError(t, err)
 
 	if nbOps(bug3) != 4 {
@@ -169,6 +173,8 @@ func _RebaseOurs(t testing.TB) {
 	defer repository.CleanupTestRepos(repoA, repoB, remote)
 
 	reneA := identity.NewIdentity("René Descartes", "rene@descartes.fr")
+	err := reneA.Commit(repoA)
+	require.NoError(t, err)
 
 	bug1, _, err := Create(reneA, time.Now().Unix(), "bug1", "message")
 	require.NoError(t, err)
@@ -220,13 +226,13 @@ func _RebaseOurs(t testing.TB) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	bugs := allBugs(t, ReadAllLocalBugs(repoA))
+	bugs := allBugs(t, ReadAllLocal(repoA))
 
 	if len(bugs) != 1 {
 		t.Fatal("Unexpected number of bugs")
 	}
 
-	bug2, err := ReadLocalBug(repoA, bug1.Id())
+	bug2, err := ReadLocal(repoA, bug1.Id())
 	require.NoError(t, err)
 
 	if nbOps(bug2) != 10 {
@@ -258,6 +264,8 @@ func _RebaseConflict(t testing.TB) {
 	defer repository.CleanupTestRepos(repoA, repoB, remote)
 
 	reneA := identity.NewIdentity("René Descartes", "rene@descartes.fr")
+	err := reneA.Commit(repoA)
+	require.NoError(t, err)
 
 	bug1, _, err := Create(reneA, time.Now().Unix(), "bug1", "message")
 	require.NoError(t, err)
@@ -305,7 +313,7 @@ func _RebaseConflict(t testing.TB) {
 	err = bug1.Commit(repoA)
 	require.NoError(t, err)
 
-	bug2, err := ReadLocalBug(repoB, bug1.Id())
+	bug2, err := ReadLocal(repoB, bug1.Id())
 	require.NoError(t, err)
 
 	reneB, err := identity.ReadLocal(repoA, reneA.Id())
@@ -346,13 +354,13 @@ func _RebaseConflict(t testing.TB) {
 	err = Pull(repoB, "origin")
 	require.NoError(t, err)
 
-	bugs := allBugs(t, ReadAllLocalBugs(repoB))
+	bugs := allBugs(t, ReadAllLocal(repoB))
 
 	if len(bugs) != 1 {
 		t.Fatal("Unexpected number of bugs")
 	}
 
-	bug3, err := ReadLocalBug(repoB, bug1.Id())
+	bug3, err := ReadLocal(repoB, bug1.Id())
 	require.NoError(t, err)
 
 	if nbOps(bug3) != 19 {
@@ -367,13 +375,13 @@ func _RebaseConflict(t testing.TB) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	bugs = allBugs(t, ReadAllLocalBugs(repoA))
+	bugs = allBugs(t, ReadAllLocal(repoA))
 
 	if len(bugs) != 1 {
 		t.Fatal("Unexpected number of bugs")
 	}
 
-	bug4, err := ReadLocalBug(repoA, bug1.Id())
+	bug4, err := ReadLocal(repoA, bug1.Id())
 	require.NoError(t, err)
 
 	if nbOps(bug4) != 19 {

--- a/bug/clocks.go
+++ b/bug/clocks.go
@@ -1,6 +1,7 @@
 package bug
 
 import (
+	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/repository"
 )
 
@@ -8,7 +9,9 @@ import (
 var ClockLoader = repository.ClockLoader{
 	Clocks: []string{creationClockName, editClockName},
 	Witnesser: func(repo repository.ClockedRepo) error {
-		for b := range ReadAllLocalBugs(repo) {
+		// We don't care about the actual identity so an IdentityStub will do
+		resolver := identity.NewStubResolver()
+		for b := range ReadAllLocalWithResolver(repo, resolver) {
 			if b.Err != nil {
 				return b.Err
 			}

--- a/bug/operation_iterator_test.go
+++ b/bug/operation_iterator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/MichaelMure/git-bug/identity"
 	"github.com/MichaelMure/git-bug/repository"
@@ -28,6 +28,9 @@ func TestOpIterator(t *testing.T) {
 	mockRepo := repository.NewMockRepoForTest()
 
 	rene := identity.NewIdentity("René Descartes", "rene@descartes.fr")
+	err := rene.Commit(mockRepo)
+	require.NoError(t, err)
+
 	unix := time.Now().Unix()
 
 	createOp := NewCreateOp(rene, unix, "title", "message", nil)
@@ -48,15 +51,15 @@ func TestOpIterator(t *testing.T) {
 	bug1.Append(addCommentOp)
 	bug1.Append(setStatusOp)
 	bug1.Append(labelChangeOp)
-	err := bug1.Commit(mockRepo)
-	assert.NoError(t, err)
+	err = bug1.Commit(mockRepo)
+	require.NoError(t, err)
 
 	// second pack
 	bug1.Append(genTitleOp())
 	bug1.Append(genTitleOp())
 	bug1.Append(genTitleOp())
 	err = bug1.Commit(mockRepo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// staging
 	bug1.Append(genTitleOp())
@@ -71,5 +74,5 @@ func TestOpIterator(t *testing.T) {
 		counter++
 	}
 
-	assert.Equal(t, 10, counter)
+	require.Equal(t, 10, counter)
 }

--- a/bug/operation_pack.go
+++ b/bug/operation_pack.go
@@ -143,10 +143,11 @@ func (opp *OperationPack) Write(repo repository.ClockedRepo) (repository.Hash, e
 	}
 
 	// First, make sure that all the identities are properly Commit as well
+	// TODO: this might be downgraded to "make sure it exist in git" but then, what make
+	// sure no data is lost on identities ?
 	for _, op := range opp.Operations {
-		err := op.base().Author.CommitAsNeeded(repo)
-		if err != nil {
-			return "", err
+		if op.base().Author.NeedCommit() {
+			return "", fmt.Errorf("identity need commmit")
 		}
 	}
 

--- a/bug/operation_test.go
+++ b/bug/operation_test.go
@@ -106,7 +106,7 @@ func TestID(t *testing.T) {
 
 		require.Equal(t, id1, id2)
 
-		b2, err := ReadLocalBug(repo, b.Id())
+		b2, err := ReadLocal(repo, b.Id())
 		require.Nil(t, err)
 
 		op3 := b2.FirstOp()

--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -92,7 +92,7 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 	}
 
 	switch snap.Author.(type) {
-	case *identity.Identity:
+	case *identity.Identity, *IdentityCache:
 		e.AuthorId = snap.Author.Id()
 	case *identity.Bare:
 		e.LegacyAuthor = LegacyAuthorExcerpt{

--- a/cache/identity_cache.go
+++ b/cache/identity_cache.go
@@ -4,6 +4,8 @@ import (
 	"github.com/MichaelMure/git-bug/identity"
 )
 
+var _ identity.Interface = &IdentityCache{}
+
 // IdentityCache is a wrapper around an Identity for caching.
 type IdentityCache struct {
 	*identity.Identity

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -179,7 +179,7 @@ func (c *RepoCache) buildCache() error {
 
 	c.identitiesExcerpts = make(map[entity.Id]*IdentityExcerpt)
 
-	allIdentities := identity.ReadAllLocalIdentities(c.repo)
+	allIdentities := identity.ReadAllLocal(c.repo)
 
 	for i := range allIdentities {
 		if i.Err != nil {
@@ -195,7 +195,7 @@ func (c *RepoCache) buildCache() error {
 
 	c.bugExcerpts = make(map[entity.Id]*BugExcerpt)
 
-	allBugs := bug.ReadAllLocalBugs(c.repo)
+	allBugs := bug.ReadAllLocal(c.repo)
 
 	for b := range allBugs {
 		if b.Err != nil {

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -136,7 +136,7 @@ func (c *RepoCache) ResolveBug(id entity.Id) (*BugCache, error) {
 	}
 	c.muBug.RUnlock()
 
-	b, err := bug.ReadLocalBug(c.repo, id)
+	b, err := bug.ReadLocalWithResolver(c.repo, newIdentityCacheResolver(c), id)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/resolvers.go
+++ b/cache/resolvers.go
@@ -1,0 +1,22 @@
+package cache
+
+import (
+	"github.com/MichaelMure/git-bug/entity"
+	"github.com/MichaelMure/git-bug/identity"
+)
+
+var _ identity.Resolver = &identityCacheResolver{}
+
+// identityCacheResolver is an identity Resolver that retrieve identities from
+// the cache
+type identityCacheResolver struct {
+	cache *RepoCache
+}
+
+func newIdentityCacheResolver(cache *RepoCache) *identityCacheResolver {
+	return &identityCacheResolver{cache: cache}
+}
+
+func (i *identityCacheResolver) ResolveIdentity(id entity.Id) (identity.Interface, error) {
+	return i.cache.ResolveIdentity(id)
+}

--- a/identity/bare.go
+++ b/identity/bare.go
@@ -185,14 +185,14 @@ func (i *Bare) Validate() error {
 
 // Write the identity into the Repository. In particular, this ensure that
 // the Id is properly set.
-func (i *Bare) Commit(repo repository.ClockedRepo) error {
+func (i *Bare) CommitWithRepo(repo repository.ClockedRepo) error {
 	// Nothing to do, everything is directly embedded
 	return nil
 }
 
 // If needed, write the identity into the Repository. In particular, this
 // ensure that the Id is properly set.
-func (i *Bare) CommitAsNeeded(repo repository.ClockedRepo) error {
+func (i *Bare) CommitAsNeededWithRepo(repo repository.ClockedRepo) error {
 	// Nothing to do, everything is directly embedded
 	return nil
 }
@@ -211,4 +211,8 @@ func (i *Bare) LastModificationLamport() lamport.Time {
 // LastModification return the timestamp at which the last version of the identity became valid.
 func (i *Bare) LastModification() timestamp.Timestamp {
 	return 0
+}
+
+func (i *Bare) NeedCommit() bool {
+	return false
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -180,19 +180,19 @@ type StreamedIdentity struct {
 	Err      error
 }
 
-// ReadAllLocalIdentities read and parse all local Identity
-func ReadAllLocalIdentities(repo repository.ClockedRepo) <-chan StreamedIdentity {
-	return readAllIdentities(repo, identityRefPattern)
+// ReadAllLocal read and parse all local Identity
+func ReadAllLocal(repo repository.ClockedRepo) <-chan StreamedIdentity {
+	return readAll(repo, identityRefPattern)
 }
 
-// ReadAllRemoteIdentities read and parse all remote Identity for a given remote
-func ReadAllRemoteIdentities(repo repository.ClockedRepo, remote string) <-chan StreamedIdentity {
+// ReadAllRemote read and parse all remote Identity for a given remote
+func ReadAllRemote(repo repository.ClockedRepo, remote string) <-chan StreamedIdentity {
 	refPrefix := fmt.Sprintf(identityRemoteRefPattern, remote)
-	return readAllIdentities(repo, refPrefix)
+	return readAll(repo, refPrefix)
 }
 
-// Read and parse all available bug with a given ref prefix
-func readAllIdentities(repo repository.ClockedRepo, refPrefix string) <-chan StreamedIdentity {
+// readAll read and parse all available bug with a given ref prefix
+func readAll(repo repository.ClockedRepo, refPrefix string) <-chan StreamedIdentity {
 	out := make(chan StreamedIdentity)
 
 	go func() {

--- a/identity/identity_actions_test.go
+++ b/identity/identity_actions_test.go
@@ -23,7 +23,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoB, "origin")
 	require.NoError(t, err)
 
-	identities := allIdentities(t, ReadAllLocalIdentities(repoB))
+	identities := allIdentities(t, ReadAllLocal(repoB))
 
 	if len(identities) != 1 {
 		t.Fatal("Unexpected number of bugs")
@@ -40,7 +40,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	identities = allIdentities(t, ReadAllLocalIdentities(repoA))
+	identities = allIdentities(t, ReadAllLocal(repoA))
 
 	if len(identities) != 2 {
 		t.Fatal("Unexpected number of bugs")
@@ -70,7 +70,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoB, "origin")
 	require.NoError(t, err)
 
-	identities = allIdentities(t, ReadAllLocalIdentities(repoB))
+	identities = allIdentities(t, ReadAllLocal(repoB))
 
 	if len(identities) != 2 {
 		t.Fatal("Unexpected number of bugs")
@@ -84,7 +84,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	identities = allIdentities(t, ReadAllLocalIdentities(repoA))
+	identities = allIdentities(t, ReadAllLocal(repoA))
 
 	if len(identities) != 2 {
 		t.Fatal("Unexpected number of bugs")
@@ -118,7 +118,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoB, "origin")
 	require.Error(t, err)
 
-	identities = allIdentities(t, ReadAllLocalIdentities(repoB))
+	identities = allIdentities(t, ReadAllLocal(repoB))
 
 	if len(identities) != 2 {
 		t.Fatal("Unexpected number of bugs")
@@ -133,7 +133,7 @@ func TestPushPull(t *testing.T) {
 	err = Pull(repoA, "origin")
 	require.NoError(t, err)
 
-	identities = allIdentities(t, ReadAllLocalIdentities(repoA))
+	identities = allIdentities(t, ReadAllLocal(repoA))
 
 	if len(identities) != 2 {
 		t.Fatal("Unexpected number of bugs")

--- a/identity/identity_stub.go
+++ b/identity/identity_stub.go
@@ -80,11 +80,11 @@ func (IdentityStub) Validate() error {
 	panic("identities needs to be properly loaded with identity.ReadLocal()")
 }
 
-func (IdentityStub) Commit(repo repository.ClockedRepo) error {
+func (IdentityStub) CommitWithRepo(repo repository.ClockedRepo) error {
 	panic("identities needs to be properly loaded with identity.ReadLocal()")
 }
 
-func (i *IdentityStub) CommitAsNeeded(repo repository.ClockedRepo) error {
+func (i *IdentityStub) CommitAsNeededWithRepo(repo repository.ClockedRepo) error {
 	panic("identities needs to be properly loaded with identity.ReadLocal()")
 }
 
@@ -98,4 +98,8 @@ func (i *IdentityStub) LastModificationLamport() lamport.Time {
 
 func (i *IdentityStub) LastModification() timestamp.Timestamp {
 	panic("identities needs to be properly loaded with identity.ReadLocal()")
+}
+
+func (i *IdentityStub) NeedCommit() bool {
+	return false
 }

--- a/identity/interface.go
+++ b/identity/interface.go
@@ -2,14 +2,12 @@ package identity
 
 import (
 	"github.com/MichaelMure/git-bug/entity"
-	"github.com/MichaelMure/git-bug/repository"
 	"github.com/MichaelMure/git-bug/util/lamport"
 	"github.com/MichaelMure/git-bug/util/timestamp"
 )
 
 type Interface interface {
-	// Id return the Identity identifier
-	Id() entity.Id
+	entity.Interface
 
 	// Name return the last version of the name
 	// Can be empty.
@@ -45,14 +43,6 @@ type Interface interface {
 	// Validate check if the Identity data is valid
 	Validate() error
 
-	// Write the identity into the Repository. In particular, this ensure that
-	// the Id is properly set.
-	Commit(repo repository.ClockedRepo) error
-
-	// If needed, write the identity into the Repository. In particular, this
-	// ensure that the Id is properly set.
-	CommitAsNeeded(repo repository.ClockedRepo) error
-
 	// IsProtected return true if the chain of git commits started to be signed.
 	// If that's the case, only signed commit with a valid key for this identity can be added.
 	IsProtected() bool
@@ -62,4 +52,7 @@ type Interface interface {
 
 	// LastModification return the timestamp at which the last version of the identity became valid.
 	LastModification() timestamp.Timestamp
+
+	// Indicate that the in-memory state changed and need to be commit in the repository
+	NeedCommit() bool
 }

--- a/identity/resolver.go
+++ b/identity/resolver.go
@@ -11,7 +11,7 @@ type Resolver interface {
 	ResolveIdentity(id entity.Id) (Interface, error)
 }
 
-// DefaultResolver is a Resolver loading Identities directly from a Repo
+// SimpleResolver is a Resolver loading Identities directly from a Repo
 type SimpleResolver struct {
 	repo repository.Repo
 }
@@ -22,4 +22,15 @@ func NewSimpleResolver(repo repository.Repo) *SimpleResolver {
 
 func (r *SimpleResolver) ResolveIdentity(id entity.Id) (Interface, error) {
 	return ReadLocal(r.repo, id)
+}
+
+// StubResolver is a Resolver that doesn't load anything, only returning IdentityStub instances
+type StubResolver struct{}
+
+func NewStubResolver() *StubResolver {
+	return &StubResolver{}
+}
+
+func (s *StubResolver) ResolveIdentity(id entity.Id) (Interface, error) {
+	return &IdentityStub{id: id}, nil
 }

--- a/misc/random_bugs/create_random_bugs.go
+++ b/misc/random_bugs/create_random_bugs.go
@@ -157,14 +157,14 @@ func GenerateRandomOperationPacksWithSeed(packNumber int, opNumber int, seed int
 	return result
 }
 
-func person() identity.Interface {
+func person() *identity.Identity {
 	return identity.NewIdentity(fake.FullName(), fake.EmailAddress())
 }
 
-var persons []identity.Interface
+var persons []*identity.Identity
 
 func generateRandomPersons(repo repository.ClockedRepo, n int) {
-	persons = make([]identity.Interface, n)
+	persons = make([]*identity.Identity, n)
 	for i := range persons {
 		p := person()
 		err := p.Commit(repo)

--- a/tests/read_bugs_test.go
+++ b/tests/read_bugs_test.go
@@ -14,7 +14,7 @@ func TestReadBugs(t *testing.T) {
 
 	random_bugs.FillRepoWithSeed(repo, 15, 42)
 
-	bugs := bug.ReadAllLocalBugs(repo)
+	bugs := bug.ReadAllLocal(repo)
 	for b := range bugs {
 		if b.Err != nil {
 			t.Fatal(b.Err)
@@ -30,7 +30,7 @@ func benchmarkReadBugs(bugNumber int, t *testing.B) {
 	t.ResetTimer()
 
 	for n := 0; n < t.N; n++ {
-		bugs := bug.ReadAllLocalBugs(repo)
+		bugs := bug.ReadAllLocal(repo)
 		for b := range bugs {
 			if b.Err != nil {
 				t.Fatal(b.Err)


### PR DESCRIPTION
- bug doesn't commit identities anymore, only make sure they are commit
- cache use an IdentityResolver to attach cached identities to bugs (deps injection): this make sure that we don't load multiple version of the same identity and improve perfs
- IdentityCache now are identity.Interface
- some naming simplification