### PR TITLE
bridge: fix Github pull bug status/comments

### DIFF
--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -57,12 +57,21 @@ func (gi *githubImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, 
 	out := make(chan core.ImportResult)
 	gi.out = out
 
+	previousIssueId := ""
 	go func() {
 		defer close(gi.out)
 
 		// Loop over all matching issues
 		for gi.iterator.NextIssue() {
 			issue := gi.iterator.IssueValue()
+			currentIssueId := parseId(issue.Id)
+
+			if previousIssueId == currentIssueId {
+				continue
+			}
+
+			previousIssueId = currentIssueId
+
 			// create issue
 			b, err := gi.ensureIssue(repo, issue)
 			if err != nil {


### PR DESCRIPTION
The iterator can in some cases return the same issue that
was just handled. It seems to be the cause why we could see
bug getting the wrong status and comments that from another issue

Fixes: https://github.com/MichaelMure/git-bug/issues/385