### PR TITLE
fix config loading during 'git-bug bridge pull'

### DIFF
--- a/bridge/bridges_test.go
+++ b/bridge/bridges_test.go
@@ -1,0 +1,27 @@
+package bridge
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/repository"
+)
+
+func TestDefaultBridge(t *testing.T) {
+	repo := repository.CreateGoGitTestRepo(false)
+	defer repository.CleanupTestRepos(repo)
+	crepo, err := cache.NewRepoCache(repo)
+	require.NoError(t, err)
+
+	_, err = DefaultBridge(crepo)
+	require.Error(t, err) // no bridges
+
+	config := crepo.LocalConfig()
+	require.NoError(t, config.StoreString("git-bug.bridge.github.target"       , "github"     ))
+	require.NoError(t, config.StoreString("git-bug.bridge.github.project"      , "testproject"))
+	require.NoError(t, config.StoreString("git-bug.bridge.github.owner"        , "testuser"   ))
+	require.NoError(t, config.StoreString("git-bug.bridge.github.default-login", "somelogin"  ))
+	_, err = DefaultBridge(crepo)
+	require.NoError(t, err)
+}

--- a/bridge/core/bridge.go
+++ b/bridge/core/bridge.go
@@ -182,7 +182,7 @@ func ConfiguredBridges(repo repository.RepoConfig) ([]string, error) {
 
 // Check if a bridge exist
 func BridgeExist(repo repository.RepoConfig, name string) bool {
-	keyPrefix := fmt.Sprintf("git-bug.bridge.%s.", name)
+	keyPrefix := fmt.Sprintf(bridgeConfigKeyPrefix + "." + name)
 
 	conf, err := repo.LocalConfig().ReadAll(keyPrefix)
 
@@ -261,7 +261,7 @@ func (b *Bridge) ensureConfig() error {
 }
 
 func loadConfig(repo repository.RepoConfig, name string) (Configuration, error) {
-	keyPrefix := fmt.Sprintf("git-bug.bridge.%s.", name)
+	keyPrefix := bridgeConfigKeyPrefix + "." + name
 
 	pairs, err := repo.LocalConfig().ReadAll(keyPrefix)
 	if err != nil {
@@ -270,7 +270,7 @@ func loadConfig(repo repository.RepoConfig, name string) (Configuration, error) 
 
 	result := make(Configuration, len(pairs))
 	for key, value := range pairs {
-		key := strings.TrimPrefix(key, keyPrefix)
+		key := strings.TrimPrefix(key, keyPrefix + ".")
 		result[key] = value
 	}
 


### PR DESCRIPTION
Hey, not sure how/when it broke, but hopefully the fix makes sense. I guess it's kind of unfortunate that reading config is a bit scattered across the codebase, but perhaps the test will make it easier to refactor and cleanup in the future :) 