### PR TITLE
Timestamp Arguments

### DIFF
--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -76,12 +76,16 @@ func (c *BugCache) AddComment(message string) (*bug.AddCommentOperation, error) 
 }
 
 func (c *BugCache) AddCommentWithFiles(message string, files []repository.Hash) (*bug.AddCommentOperation, error) {
+	return c.AddCommentWithFilesAndTime(time.Now().Unix(), message, files)
+}
+
+func (c *BugCache) AddCommentWithFilesAndTime(unixTime int64, message string, files []repository.Hash) (*bug.AddCommentOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.AddCommentRaw(author, time.Now().Unix(), message, files, nil)
+	return c.AddCommentRaw(author, unixTime, message, files, nil)
 }
 
 func (c *BugCache) AddCommentRaw(author *IdentityCache, unixTime int64, message string, files []repository.Hash, metadata map[string]string) (*bug.AddCommentOperation, error) {

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -167,12 +167,16 @@ func (c *BugCache) ForceChangeLabelsRaw(author *IdentityCache, unixTime int64, a
 }
 
 func (c *BugCache) Open() (*bug.SetStatusOperation, error) {
+	return c.OpenWithTime(time.Now().Unix())
+}
+
+func (c *BugCache) OpenWithTime(unixTime int64) (*bug.SetStatusOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.OpenRaw(author, time.Now().Unix(), nil)
+	return c.OpenRaw(author, unixTime, nil)
 }
 
 func (c *BugCache) OpenRaw(author *IdentityCache, unixTime int64, metadata map[string]string) (*bug.SetStatusOperation, error) {
@@ -192,12 +196,16 @@ func (c *BugCache) OpenRaw(author *IdentityCache, unixTime int64, metadata map[s
 }
 
 func (c *BugCache) Close() (*bug.SetStatusOperation, error) {
+	return c.CloseWithTime(time.Now().Unix())
+}
+
+func (c *BugCache) CloseWithTime(unixTime int64) (*bug.SetStatusOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.CloseRaw(author, time.Now().Unix(), nil)
+	return c.CloseRaw(author, unixTime, nil)
 }
 
 func (c *BugCache) CloseRaw(author *IdentityCache, unixTime int64, metadata map[string]string) (*bug.SetStatusOperation, error) {

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -353,12 +353,18 @@ func (c *RepoCache) NewBug(title string, message string) (*BugCache, *bug.Create
 // NewBugWithFiles create a new bug with attached files for the message
 // The new bug is written in the repository (commit)
 func (c *RepoCache) NewBugWithFiles(title string, message string, files []repository.Hash) (*BugCache, *bug.CreateOperation, error) {
+	return c.NewBugWithFilesAndTime(time.Now().Unix(), title, message, files)
+}
+
+// NewBugWithFiles create a new bug with attached files for the message and timestamp
+// The new bug is written in the repository (commit)
+func (c *RepoCache) NewBugWithFilesAndTime(unixTime int64, title string, message string, files []repository.Hash) (*BugCache, *bug.CreateOperation, error) {
 	author, err := c.GetUserIdentity()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return c.NewBugRaw(author, time.Now().Unix(), title, message, files, nil)
+	return c.NewBugRaw(author, unixTime, title, message, files, nil)
 }
 
 // NewBugWithFilesMeta create a new bug with attached files for the message, as

--- a/commands/add.go
+++ b/commands/add.go
@@ -39,7 +39,7 @@ func newAddCommand() *cobra.Command {
 	flags.StringVarP(&options.messageFile, "file", "F", "",
 		"Take the message from the given file. Use - to read the message from the standard input")
 	flags.Int64VarP(&options.unixTime, "time", "u", 0,
-		"Set the unix timestamp of the commit, in number of seconds since 1970-01-01")
+		"Set the unix timestamp of the commit, in seconds since 1970-01-01")
 
 	return cmd
 }

--- a/commands/add.go
+++ b/commands/add.go
@@ -4,12 +4,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/MichaelMure/git-bug/input"
+
+	"time"
 )
 
 type addOptions struct {
 	title       string
 	message     string
 	messageFile string
+	unixTime    int64
 }
 
 func newAddCommand() *cobra.Command {
@@ -35,6 +38,8 @@ func newAddCommand() *cobra.Command {
 		"Provide a message to describe the issue")
 	flags.StringVarP(&options.messageFile, "file", "F", "",
 		"Take the message from the given file. Use - to read the message from the standard input")
+	flags.Int64VarP(&options.unixTime, "time", "u", 0,
+		"Set the unix timestamp of the commit, in number of seconds since 1970-01-01")
 
 	return cmd
 }
@@ -60,7 +65,12 @@ func runAdd(env *Env, opts addOptions) error {
 		}
 	}
 
-	b, _, err := env.backend.NewBug(opts.title, opts.message)
+	if opts.unixTime == 0 {
+		opts.unixTime = time.Now().Unix()
+	}
+
+	b, _, err := env.backend.NewBugWithFilesAndTime(opts.unixTime, opts.title, opts.message, nil)
+
 	if err != nil {
 		return err
 	}

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -5,11 +5,14 @@ import (
 
 	_select "github.com/MichaelMure/git-bug/commands/select"
 	"github.com/MichaelMure/git-bug/input"
+
+	"time"
 )
 
 type commentAddOptions struct {
 	messageFile string
 	message     string
+	unixTime    int64
 }
 
 func newCommentAddCommand() *cobra.Command {
@@ -34,6 +37,9 @@ func newCommentAddCommand() *cobra.Command {
 
 	flags.StringVarP(&options.message, "message", "m", "",
 		"Provide the new message from the command line")
+
+	flags.Int64VarP(&options.unixTime, "time", "u", 0,
+		"Set the unix timestamp of the commit, in number of seconds since 1970-01-01")
 
 	return cmd
 }
@@ -62,7 +68,11 @@ func runCommentAdd(env *Env, opts commentAddOptions, args []string) error {
 		}
 	}
 
-	_, err = b.AddComment(opts.message)
+	if opts.unixTime == 0 {
+		opts.unixTime = time.Now().Unix()
+	}
+
+	_, err = b.AddCommentWithFilesAndTime(opts.unixTime, opts.message, nil)
 	if err != nil {
 		return err
 	}

--- a/commands/comment_add.go
+++ b/commands/comment_add.go
@@ -39,7 +39,7 @@ func newCommentAddCommand() *cobra.Command {
 		"Provide the new message from the command line")
 
 	flags.Int64VarP(&options.unixTime, "time", "u", 0,
-		"Set the unix timestamp of the commit, in number of seconds since 1970-01-01")
+		"Set the unix timestamp of the commit, in seconds since 1970-01-01")
 
 	return cmd
 }

--- a/commands/status_close.go
+++ b/commands/status_close.go
@@ -3,10 +3,17 @@ package commands
 import (
 	_select "github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
+
+	"time"
 )
+
+type statusCloseOptions struct {
+	unixTime    int64
+}
 
 func newStatusCloseCommand() *cobra.Command {
 	env := newEnv()
+	options := statusCloseOptions{}
 
 	cmd := &cobra.Command{
 		Use:      "close [ID]",
@@ -14,20 +21,30 @@ func newStatusCloseCommand() *cobra.Command {
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatusClose(env, args)
+			return runStatusClose(env, args, options)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+
+	flags.Int64VarP(&options.unixTime, "time", "u", 0,
+		"Set the unix timestamp of a status change, in seconds since 1970-01-01")
 
 	return cmd
 }
 
-func runStatusClose(env *Env, args []string) error {
+func runStatusClose(env *Env, args []string, opts statusCloseOptions) error {
 	b, args, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
 		return err
 	}
 
-	_, err = b.Close()
+	if opts.unixTime == 0 {
+		opts.unixTime = time.Now().Unix()
+	}
+
+	_, err = b.CloseWithTime(opts.unixTime)
 	if err != nil {
 		return err
 	}

--- a/commands/status_open.go
+++ b/commands/status_open.go
@@ -3,10 +3,17 @@ package commands
 import (
 	_select "github.com/MichaelMure/git-bug/commands/select"
 	"github.com/spf13/cobra"
+
+	"time"
 )
+
+type statusOpenOptions struct {
+	unixTime    int64
+}
 
 func newStatusOpenCommand() *cobra.Command {
 	env := newEnv()
+	options := statusOpenOptions{}
 
 	cmd := &cobra.Command{
 		Use:      "open [ID]",
@@ -14,20 +21,30 @@ func newStatusOpenCommand() *cobra.Command {
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatusOpen(env, args)
+			return runStatusOpen(env, args, options)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+
+	flags.Int64VarP(&options.unixTime, "time", "u", 0,
+		"Set the unix timestamp of a status change, in seconds since 1970-01-01")
 
 	return cmd
 }
 
-func runStatusOpen(env *Env, args []string) error {
+func runStatusOpen(env *Env, args []string, opts statusOpenOptions) error {
 	b, args, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
 		return err
 	}
 
-	_, err = b.Open()
+	if opts.unixTime == 0 {
+		opts.unixTime = time.Now().Unix()
+	}
+
+	_, err = b.OpenWithTime(opts.unixTime)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a command line argument to bug creation, commenting, and status changing, that lets one change the timestamp from the present.

The purpose is to facilitate using git-bug inside single-use scripts to import issues from archives, addressing the reason I opened issue #489 .

The changes are minor, but I have never coded in go before, and mostly copied structures from elsewhere in the repository to accomplish this.