### PR TITLE
Fix #656

### DIFF
--- a/webui/src/components/CommentInput/CommentInput.tsx
+++ b/webui/src/components/CommentInput/CommentInput.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles((theme) => ({
     margin: theme.spacing(2, 0),
   },
   preview: {
+    overflow: 'auto',
     borderBottom: `solid 3px ${theme.palette.grey['200']}`,
     minHeight: '5rem',
   },

--- a/webui/src/pages/bug/Message.tsx
+++ b/webui/src/pages/bug/Message.tsx
@@ -57,6 +57,7 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: '0.5rem',
   },
   body: {
+    overflow: 'auto',
     ...theme.typography.body2,
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),

--- a/webui/src/pages/bug/MessageHistoryDialog.tsx
+++ b/webui/src/pages/bug/MessageHistoryDialog.tsx
@@ -111,6 +111,7 @@ const AccordionSummary = withStyles((theme) => ({
 const AccordionDetails = withStyles((theme) => ({
   root: {
     display: 'block',
+    overflow: 'auto',
     padding: theme.spacing(2),
   },
 }))(MuiAccordionDetails);


### PR DESCRIPTION
Fix #656 
Very long words wont any longer overflow over the parent container boundary.
Instead a scrollbar will be shown.