### PR TITLE
WebUI: Support comment-and-close of a bug in one step

### DIFF
--- a/webui/src/components/CloseBugWithCommentButton/CloseBugWithComment.graphql
+++ b/webui/src/components/CloseBugWithCommentButton/CloseBugWithComment.graphql
@@ -1,0 +1,11 @@
+mutation AddCommentAndCloseBug($input: AddCommentAndCloseBugInput!) {
+  addCommentAndClose(input: $input) {
+    statusOperation {
+      status
+    }
+    commentOperation {
+      message
+    }
+  }
+}
+

--- a/webui/src/components/CloseBugWithCommentButton/CloseBugWithCommentButton.tsx
+++ b/webui/src/components/CloseBugWithCommentButton/CloseBugWithCommentButton.tsx
@@ -7,7 +7,7 @@ import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import { BugFragment } from 'src/pages/bug/Bug.generated';
 import { TimelineDocument } from 'src/pages/bug/TimelineQuery.generated';
 
-import { useCloseBugMutation } from './CloseBug.generated';
+import { useAddCommentAndCloseBugMutation } from './CloseBugWithComment.generated';
 
 const useStyles = makeStyles((theme: Theme) => ({
   closeIssueIcon: {
@@ -18,18 +18,22 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   bug: BugFragment;
-  disabled?: boolean;
+  comment: string;
 }
 
-function CloseBugButton({ bug, disabled }: Props) {
-  const [closeBug, { loading, error }] = useCloseBugMutation();
+function CloseBugWithCommentButton({ bug, comment }: Props) {
+  const [
+    addCommentAndCloseBug,
+    { loading, error },
+  ] = useAddCommentAndCloseBugMutation();
   const classes = useStyles();
 
-  function closeBugAction() {
-    closeBug({
+  function addCommentAndCloseBugAction() {
+    addCommentAndCloseBug({
       variables: {
         input: {
           prefix: bug.id,
+          message: comment,
         },
       },
       refetchQueries: [
@@ -53,14 +57,13 @@ function CloseBugButton({ bug, disabled }: Props) {
     <div>
       <Button
         variant="contained"
-        onClick={() => closeBugAction()}
-        disabled={bug.status === 'CLOSED' || disabled}
+        onClick={() => addCommentAndCloseBugAction()}
         startIcon={<ErrorOutlineIcon className={classes.closeIssueIcon} />}
       >
-        Close bug
+        Close bug with comment
       </Button>
     </div>
   );
 }
 
-export default CloseBugButton;
+export default CloseBugWithCommentButton;

--- a/webui/src/pages/bug/CommentForm.tsx
+++ b/webui/src/pages/bug/CommentForm.tsx
@@ -6,6 +6,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 
 import CommentInput from '../../components/CommentInput/CommentInput';
 import CloseBugButton from 'src/components/CloseBugButton/CloseBugButton';
+import CloseBugWithCommentButton from 'src/components/CloseBugWithCommentButton/CloseBugWithCommentButton';
 import ReopenBugButton from 'src/components/ReopenBugButton/ReopenBugButton';
 
 import { BugFragment } from './Bug.generated';
@@ -77,12 +78,14 @@ function CommentForm({ bug }: Props) {
     if (issueComment.length > 0) submit();
   };
 
-  function getCloseButton() {
-    return <CloseBugButton bug={bug} disabled={issueComment.length > 0} />;
-  }
-
-  function getReopenButton() {
-    return <ReopenBugButton bug={bug} disabled={issueComment.length > 0} />;
+  function getBugStatusButton() {
+    if (bug.status === 'OPEN' && issueComment.length > 0) {
+      return <CloseBugWithCommentButton bug={bug} comment={issueComment} />;
+    } else if (bug.status === 'OPEN') {
+      return <CloseBugButton bug={bug} />;
+    } else {
+      return <ReopenBugButton bug={bug} disabled={issueComment.length > 0} />;
+    }
   }
 
   return (
@@ -94,7 +97,7 @@ function CommentForm({ bug }: Props) {
           onChange={(comment: string) => setIssueComment(comment)}
         />
         <div className={classes.actions}>
-          {bug.status === 'OPEN' ? getCloseButton() : getReopenButton()}
+          {getBugStatusButton()}
           <Button
             className={classes.greenButton}
             variant="contained"


### PR DESCRIPTION
When a user has some text entered in the comment field, the close bug button will change to "Close bug with comment". 
This way the user does not have to comment and close a bug in two separate steps.