### PR TITLE
feature: Github bridge mutation rate limit

### DIFF
--- a/bridge/core/export.go
+++ b/bridge/core/export.go
@@ -31,6 +31,9 @@ const (
 	// but not severe enough to consider the export a failure.
 	ExportEventWarning
 
+	// The export system (web API) has reached a rate limit
+	ExportEventRateLimiting
+
 	// Error happened during export
 	ExportEventError
 )
@@ -74,6 +77,8 @@ func (er ExportResult) String() string {
 			return fmt.Sprintf("warning at %s: %s", er.ID, er.Err.Error())
 		}
 		return fmt.Sprintf("warning: %s", er.Err.Error())
+	case ExportEventRateLimiting:
+		return fmt.Sprintf("rate limiting: %s", er.Reason)
 
 	default:
 		panic("unknown export result")
@@ -143,5 +148,12 @@ func NewExportTitleEdition(id entity.Id) ExportResult {
 	return ExportResult{
 		ID:    id,
 		Event: ExportEventTitleEdition,
+	}
+}
+
+func NewExportRateLimiting(msg string) ExportResult {
+	return ExportResult{
+		Reason: msg,
+		Event:  ExportEventRateLimiting,
 	}
 }

--- a/bridge/github/client.go
+++ b/bridge/github/client.go
@@ -57,9 +57,7 @@ func (c *client) queryWithLimitEvents(ctx context.Context, query interface{}, va
 
 // queryPrintMsgs calls the github api with a graphql query and it prints for ever rate limiting event a message to stdout.
 func (c *client) queryPrintMsgs(ctx context.Context, query interface{}, vars map[string]interface{}) error {
-	queryFun := func(ctx context.Context) error {
-		return c.sc.Query(ctx, query, vars)
-	}
+	// print rate limiting events directly to stdout.
 	limitEvents := make(chan RateLimitingEvent)
 	defer close(limitEvents)
 	go func() {
@@ -67,7 +65,7 @@ func (c *client) queryPrintMsgs(ctx context.Context, query interface{}, vars map
 			fmt.Println(e.msg)
 		}
 	}()
-	return c.callWithRetry(queryFun, ctx, limitEvents)
+	return c.queryWithLimitEvents(ctx, query, vars, limitEvents)
 }
 
 // queryWithImportEvents calls the github api with a graphql query and it sends rate limiting events to the channel of import events.

--- a/bridge/github/client.go
+++ b/bridge/github/client.go
@@ -1,0 +1,171 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MichaelMure/git-bug/bridge/core"
+	"github.com/shurcooL/githubv4"
+)
+
+// client wrapps the Github GraphQL client from github.com/shurcool/githubv4
+// and adds revised error handling and handling of Github's GraphQL rate limit.
+type client struct {
+	// the client from  github.com/shurcool/githubv4
+	sc *githubv4.Client
+}
+
+func newClient(httpClient *http.Client) *client {
+	return &client{sc: githubv4.NewClient(httpClient)}
+}
+
+type RateLimitingEvent struct {
+	msg string
+}
+
+// mutate calls the github api with a graphql mutation and it emits for each rate limiting event an export result.
+func (c *client) mutate(ctx context.Context, m interface{}, input githubv4.Input, vars map[string]interface{}, out chan<- core.ExportResult) error {
+	// prepare a closure for the mutation
+	mutFun := func(ctx context.Context) error {
+		return c.sc.Mutate(ctx, m, input, vars)
+	}
+	limitEvents := make(chan RateLimitingEvent)
+	defer close(limitEvents)
+	go func() {
+		for e := range limitEvents {
+			select {
+			case <-ctx.Done():
+				return
+			case out <- core.NewExportRateLimiting(e.msg):
+			}
+		}
+	}()
+	return c.callWithRetry(mutFun, ctx, limitEvents)
+}
+
+// queryWithLimitEvents calls the github api with a graphql query and it sends rate limiting events on the channel limitEvents.
+func (c *client) queryWithLimitEvents(ctx context.Context, query interface{}, vars map[string]interface{}, limitEvents chan<- RateLimitingEvent) error {
+	// prepare a closure fot the query
+	queryFun := func(ctx context.Context) error {
+		return c.sc.Query(ctx, query, vars)
+	}
+	return c.callWithRetry(queryFun, ctx, limitEvents)
+}
+
+// queryPrintMsgs calls the github api with a graphql query and it prints for ever rate limiting event a message to stdout.
+func (c *client) queryPrintMsgs(ctx context.Context, query interface{}, vars map[string]interface{}) error {
+	queryFun := func(ctx context.Context) error {
+		return c.sc.Query(ctx, query, vars)
+	}
+	limitEvents := make(chan RateLimitingEvent)
+	defer close(limitEvents)
+	go func() {
+		for e := range limitEvents {
+			fmt.Println(e.msg)
+		}
+	}()
+	return c.callWithRetry(queryFun, ctx, limitEvents)
+}
+
+// queryWithImportEvents calls the github api with a graphql query and it sends rate limiting events to the channel of import events.
+func (c *client) queryWithImportEvents(ctx context.Context, query interface{}, vars map[string]interface{}, importEvents chan<- ImportEvent) error {
+	// forward rate limiting events to channel of import events
+	limitEvents := make(chan RateLimitingEvent)
+	defer close(limitEvents)
+	go func() {
+		for e := range limitEvents {
+			select {
+			case <-ctx.Done():
+				return
+			case importEvents <- e:
+			}
+		}
+	}()
+	return c.queryWithLimitEvents(ctx, query, vars, limitEvents)
+}
+
+func (c *client) callWithRetry(fun func(context.Context) error, ctx context.Context, events chan<- RateLimitingEvent) error {
+	var err error
+	if err = c.callWithLimit(fun, ctx, events); err == nil {
+		return nil
+	}
+	// failure; the reason may be temporary network problems or internal errors
+	// on the github servers. Internal errors on the github servers are quite common.
+	// Retry
+	retries := 3
+	for i := 0; i < retries; i++ {
+		// wait a few seconds before retry
+		sleepTime := time.Duration(8*(i+1)) * time.Second
+		timer := time.NewTimer(sleepTime)
+		select {
+		case <-ctx.Done():
+			stop(timer)
+			return ctx.Err()
+		case <-timer.C:
+			err = c.callWithLimit(fun, ctx, events)
+			if err == nil {
+				return nil
+			}
+		}
+	}
+	return err
+}
+
+func (c *client) callWithLimit(fun func(context.Context) error, ctx context.Context, events chan<- RateLimitingEvent) error {
+	qctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	// call the function fun()
+	err := fun(qctx)
+	if err == nil {
+		return nil
+	}
+	// matching the error string
+	if strings.Contains(err.Error(), "API rate limit exceeded") {
+		// a rate limit error
+		qctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+		// Use a separate query to get Github rate limiting information.
+		limitQuery := rateLimitQuery{}
+		if err := c.sc.Query(qctx, &limitQuery, map[string]interface{}{}); err != nil {
+			return err
+		}
+		// Get the time when Github will reset the rate limit of their API.
+		resetTime := limitQuery.RateLimit.ResetAt.Time
+		// Add a few seconds for good measure
+		resetTime = resetTime.Add(8 * time.Second)
+		msg := fmt.Sprintf("Github GraphQL API rate limit. This process will sleep until %s.", resetTime.String())
+		// Send message about rate limiting event.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case events <- RateLimitingEvent{msg}:
+		}
+		// Pause current goroutine
+		timer := time.NewTimer(time.Until(resetTime))
+		select {
+		case <-ctx.Done():
+			stop(timer)
+			return ctx.Err()
+		case <-timer.C:
+		}
+		// call the function fun() again
+		qctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+		err = fun(qctx)
+		return err // might be nil
+	} else {
+		return err
+	}
+}
+
+func stop(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}

--- a/bridge/github/config.go
+++ b/bridge/github/config.go
@@ -563,7 +563,7 @@ func getLoginFromToken(token *auth.Token) (string, error) {
 
 	var q loginQuery
 
-	err := client.Query(ctx, &q, nil)
+	err := client.queryPrintMsgs(ctx, &q, nil)
 	if err != nil {
 		return "", err
 	}

--- a/bridge/github/export.go
+++ b/bridge/github/export.go
@@ -597,11 +597,9 @@ func (ge *githubExporter) createGithubLabelV4(gc *githubv4.Client, label, labelC
 		Color:        githubv4.String(labelColor),
 	}
 
-	parentCtx := context.Background()
-	ctx, cancel := context.WithTimeout(parentCtx, defaultTimeout)
-	defer cancel()
+	ctx := context.Background()
 
-	if err := gc.Mutate(ctx, &m, input, nil); err != nil {
+	if err := gc.mutate(ctx, &m, input, nil); err != nil {
 		return "", err
 	}
 
@@ -664,9 +662,6 @@ func (ge *githubExporter) createGithubIssue(ctx context.Context, gc *client, rep
 		Body:         (*githubv4.String)(&body),
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return "", "", err
 	}
@@ -683,9 +678,6 @@ func (ge *githubExporter) addCommentGithubIssue(ctx context.Context, gc *client,
 		Body:      githubv4.String(body),
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return "", "", err
 	}
@@ -700,9 +692,6 @@ func (ge *githubExporter) editCommentGithubIssue(ctx context.Context, gc *client
 		ID:   commentID,
 		Body: githubv4.String(body),
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
 
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return "", "", err
@@ -731,9 +720,6 @@ func (ge *githubExporter) updateGithubIssueStatus(ctx context.Context, gc *clien
 		State: &state,
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return err
 	}
@@ -747,9 +733,6 @@ func (ge *githubExporter) updateGithubIssueBody(ctx context.Context, gc *client,
 		ID:   id,
 		Body: (*githubv4.String)(&body),
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
 
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return err
@@ -765,9 +748,6 @@ func (ge *githubExporter) updateGithubIssueTitle(ctx context.Context, gc *client
 		Title: (*githubv4.String)(&title),
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-
 	if err := gc.mutate(ctx, m, input, nil, ge.out); err != nil {
 		return err
 	}
@@ -777,8 +757,6 @@ func (ge *githubExporter) updateGithubIssueTitle(ctx context.Context, gc *client
 
 // update github issue labels
 func (ge *githubExporter) updateGithubIssueLabels(ctx context.Context, gc *client, labelableID string, added, removed []bug.Label) error {
-	reqCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
 
 	wg, ctx := errgroup.WithContext(ctx)
 	if len(added) > 0 {
@@ -795,7 +773,7 @@ func (ge *githubExporter) updateGithubIssueLabels(ctx context.Context, gc *clien
 			}
 
 			// add labels
-			if err := gc.mutate(reqCtx, m, inputAdd, nil, ge.out); err != nil {
+			if err := gc.mutate(ctx, m, inputAdd, nil, ge.out); err != nil {
 				return err
 			}
 			return nil
@@ -816,7 +794,7 @@ func (ge *githubExporter) updateGithubIssueLabels(ctx context.Context, gc *clien
 			}
 
 			// remove label labels
-			if err := gc.mutate(reqCtx, m2, inputRemove, nil, ge.out); err != nil {
+			if err := gc.mutate(ctx, m2, inputRemove, nil, ge.out); err != nil {
 				return err
 			}
 			return nil

--- a/bridge/github/github.go
+++ b/bridge/github/github.go
@@ -46,11 +46,10 @@ func (*Github) NewExporter() core.Exporter {
 	return &githubExporter{}
 }
 
-func buildClient(token *auth.Token) *client {
+func buildClient(token *auth.Token) *rateLimitHandlerClient {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token.Value},
 	)
 	httpClient := oauth2.NewClient(context.TODO(), src)
-
-	return newClient(httpClient)
+	return newRateLimitHandlerClient(httpClient)
 }

--- a/bridge/github/github.go
+++ b/bridge/github/github.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 
 	"github.com/MichaelMure/git-bug/bridge/core"
@@ -47,11 +46,11 @@ func (*Github) NewExporter() core.Exporter {
 	return &githubExporter{}
 }
 
-func buildClient(token *auth.Token) *githubv4.Client {
+func buildClient(token *auth.Token) *client {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token.Value},
 	)
 	httpClient := oauth2.NewClient(context.TODO(), src)
 
-	return githubv4.NewClient(httpClient)
+	return newClient(httpClient)
 }

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -22,7 +22,7 @@ type githubImporter struct {
 	conf core.Configuration
 
 	// default client
-	client *githubv4.Client
+	client *client
 
 	// mediator to access the Github API
 	mediator *importMediator

--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -22,7 +22,7 @@ type githubImporter struct {
 	conf core.Configuration
 
 	// default client
-	client *client
+	client *rateLimitHandlerClient
 
 	// mediator to access the Github API
 	mediator *importMediator
@@ -73,6 +73,7 @@ func (gi *githubImporter) ImportAll(ctx context.Context, repo *cache.RepoCache, 
 			// Exactly the same is true for comments and comment edits.
 			// As a consequence we need to look at the current event and one look ahead
 			// event.
+
 			currEvent = nextEvent
 			if currEvent == nil {
 				currEvent = gi.getEventHandleMsgs()

--- a/bridge/github/import_mediator.go
+++ b/bridge/github/import_mediator.go
@@ -20,7 +20,7 @@ const (
 // importMediator provides a convenient interface to retrieve issues from the Github GraphQL API.
 type importMediator struct {
 	// Github graphql client
-	gh *client
+	gh *rateLimitHandlerClient
 
 	// name of the repository owner on Github
 	owner string
@@ -78,7 +78,7 @@ func (mm *importMediator) NextImportEvent() ImportEvent {
 	return <-mm.importEvents
 }
 
-func NewImportMediator(ctx context.Context, client *client, owner, project string, since time.Time) *importMediator {
+func NewImportMediator(ctx context.Context, client *rateLimitHandlerClient, owner, project string, since time.Time) *importMediator {
 	mm := importMediator{
 		gh:           client,
 		owner:        owner,

--- a/bridge/github/import_mediator.go
+++ b/bridge/github/import_mediator.go
@@ -2,8 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -22,7 +20,7 @@ const (
 // importMediator provides a convenient interface to retrieve issues from the Github GraphQL API.
 type importMediator struct {
 	// Github graphql client
-	gc *githubv4.Client
+	gh *client
 
 	// name of the repository owner on Github
 	owner string
@@ -45,10 +43,6 @@ type importMediator struct {
 
 type ImportEvent interface {
 	isImportEvent()
-}
-
-type RateLimitingEvent struct {
-	msg string
 }
 
 func (RateLimitingEvent) isImportEvent() {}
@@ -84,9 +78,9 @@ func (mm *importMediator) NextImportEvent() ImportEvent {
 	return <-mm.importEvents
 }
 
-func NewImportMediator(ctx context.Context, client *githubv4.Client, owner, project string, since time.Time) *importMediator {
+func NewImportMediator(ctx context.Context, client *client, owner, project string, since time.Time) *importMediator {
 	mm := importMediator{
-		gc:           client,
+		gh:           client,
 		owner:        owner,
 		project:      project,
 		since:        since,
@@ -144,7 +138,7 @@ func (mm *importMediator) Error() error {
 func (mm *importMediator) User(ctx context.Context, loginName string) (*user, error) {
 	query := userQuery{}
 	vars := varmap{"login": githubv4.String(loginName)}
-	if err := mm.mQuery(ctx, &query, vars); err != nil {
+	if err := mm.gh.queryWithImportEvents(ctx, &query, vars, mm.importEvents); err != nil {
 		return nil, err
 	}
 	return &query.User, nil
@@ -206,7 +200,7 @@ func (mm *importMediator) queryIssueEdits(ctx context.Context, nid githubv4.ID, 
 		vars["issueEditBefore"] = cursor
 	}
 	query := issueEditQuery{}
-	if err := mm.mQuery(ctx, &query, vars); err != nil {
+	if err := mm.gh.queryWithImportEvents(ctx, &query, vars, mm.importEvents); err != nil {
 		mm.err = err
 		return nil, false
 	}
@@ -250,7 +244,7 @@ func (mm *importMediator) queryTimeline(ctx context.Context, nid githubv4.ID, cu
 		vars["timelineAfter"] = cursor
 	}
 	query := timelineQuery{}
-	if err := mm.mQuery(ctx, &query, vars); err != nil {
+	if err := mm.gh.queryWithImportEvents(ctx, &query, vars, mm.importEvents); err != nil {
 		mm.err = err
 		return nil, false
 	}
@@ -300,7 +294,7 @@ func (mm *importMediator) queryCommentEdits(ctx context.Context, nid githubv4.ID
 		vars["commentEditBefore"] = cursor
 	}
 	query := commentEditQuery{}
-	if err := mm.mQuery(ctx, &query, vars); err != nil {
+	if err := mm.gh.queryWithImportEvents(ctx, &query, vars, mm.importEvents); err != nil {
 		mm.err = err
 		return nil, false
 	}
@@ -319,7 +313,7 @@ func (mm *importMediator) queryIssue(ctx context.Context, cursor githubv4.String
 		vars["issueAfter"] = cursor
 	}
 	query := issueQuery{}
-	if err := mm.mQuery(ctx, &query, vars); err != nil {
+	if err := mm.gh.queryWithImportEvents(ctx, &query, vars, mm.importEvents); err != nil {
 		mm.err = err
 		return nil, false
 	}
@@ -339,98 +333,4 @@ func reverse(eds []userContentEdit) chan userContentEdit {
 		close(ret)
 	}()
 	return ret
-}
-
-// mQuery executes a single GraphQL query. The variable query is used to derive the GraphQL query
-// and it is used to populate the response into it. It should be a pointer to a struct that
-// corresponds to the Github graphql schema and it has to implement the rateLimiter interface. If
-// there is a Github rate limiting error, then the function sleeps and retries after the rate limit
-// is expired. If there is another error, then the method will retry before giving up.
-func (mm *importMediator) mQuery(ctx context.Context, query rateLimiter, vars map[string]interface{}) error {
-	if err := mm.queryOnce(ctx, query, vars); err == nil {
-		// success: done
-		return nil
-	}
-	// failure: we will retry
-	// To retry is important for importing projects with a big number of issues, because
-	// there may be temporary network errors or momentary internal errors of the github servers.
-	retries := 3
-	var err error
-	for i := 0; i < retries; i++ {
-		// wait a few seconds before retry
-		sleepTime := time.Duration(8*(i+1)) * time.Second
-		timer := time.NewTimer(sleepTime)
-		select {
-		case <-ctx.Done():
-			stop(timer)
-			return ctx.Err()
-		case <-timer.C:
-		}
-		err = mm.queryOnce(ctx, query, vars)
-		if err == nil {
-			// success: done
-			return nil
-		}
-	}
-	return err
-}
-
-func (mm *importMediator) queryOnce(ctx context.Context, query rateLimiter, vars map[string]interface{}) error {
-	// first: just send the query to the graphql api
-	vars["dryRun"] = githubv4.Boolean(false)
-	qctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-	err := mm.gc.Query(qctx, query, vars)
-	if err == nil {
-		// no error: done
-		return nil
-	}
-	// matching the error string
-	if !strings.Contains(err.Error(), "API rate limit exceeded") {
-		// an error, but not the API rate limit error: done
-		return err
-	}
-	// a rate limit error
-	// ask the graphql api for rate limiting information
-	vars["dryRun"] = githubv4.Boolean(true)
-	qctx, cancel = context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-	if err := mm.gc.Query(qctx, query, vars); err != nil {
-		return err
-	}
-	rateLimit := query.rateLimit()
-	if rateLimit.Cost > rateLimit.Remaining {
-		// sleep
-		resetTime := rateLimit.ResetAt.Time
-		// Add a few seconds (8) for good measure
-		resetTime = resetTime.Add(8 * time.Second)
-		msg := fmt.Sprintf("Github GraphQL API: import will sleep until %s", resetTime.String())
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case mm.importEvents <- RateLimitingEvent{msg}:
-		}
-		timer := time.NewTimer(time.Until(resetTime))
-		select {
-		case <-ctx.Done():
-			stop(timer)
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
-	// run the original query again
-	vars["dryRun"] = githubv4.Boolean(false)
-	qctx, cancel = context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-	err = mm.gc.Query(qctx, query, vars)
-	return err // might be nil
-}
-
-func stop(t *time.Timer) {
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
-	}
 }

--- a/bridge/github/import_query.go
+++ b/bridge/github/import_query.go
@@ -2,30 +2,19 @@ package github
 
 import "github.com/shurcooL/githubv4"
 
-type rateLimit struct {
-	Cost      githubv4.Int
-	Limit     githubv4.Int
-	NodeCount githubv4.Int
-	Remaining githubv4.Int
-	ResetAt   githubv4.DateTime
-	Used      githubv4.Int
-}
-
-type rateLimiter interface {
-	rateLimit() rateLimit
+type rateLimitQuery struct {
+	RateLimit struct {
+		ResetAt githubv4.DateTime
+		//Limit     githubv4.Int
+		//Remaining githubv4.Int
+	}
 }
 
 type userQuery struct {
-	RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
-	User      user      `graphql:"user(login: $login)"`
-}
-
-func (q *userQuery) rateLimit() rateLimit {
-	return q.RateLimit
+	User user `graphql:"user(login: $login)"`
 }
 
 type labelsQuery struct {
-	//RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
 	Repository struct {
 		Labels struct {
 			Nodes []struct {
@@ -40,26 +29,19 @@ type labelsQuery struct {
 }
 
 type loginQuery struct {
-	//RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
 	Viewer struct {
 		Login string `graphql:"login"`
 	} `graphql:"viewer"`
 }
 
 type issueQuery struct {
-	RateLimit  rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
 	Repository struct {
 		Issues issueConnection `graphql:"issues(first: $issueFirst, after: $issueAfter, orderBy: {field: CREATED_AT, direction: ASC}, filterBy: {since: $issueSince})"`
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
-func (q *issueQuery) rateLimit() rateLimit {
-	return q.RateLimit
-}
-
 type issueEditQuery struct {
-	RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
-	Node      struct {
+	Node struct {
 		Typename githubv4.String `graphql:"__typename"`
 		Issue    struct {
 			UserContentEdits userContentEditConnection `graphql:"userContentEdits(last: $issueEditLast, before: $issueEditBefore)"`
@@ -67,13 +49,8 @@ type issueEditQuery struct {
 	} `graphql:"node(id: $gqlNodeId)"`
 }
 
-func (q *issueEditQuery) rateLimit() rateLimit {
-	return q.RateLimit
-}
-
 type timelineQuery struct {
-	RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
-	Node      struct {
+	Node struct {
 		Typename githubv4.String `graphql:"__typename"`
 		Issue    struct {
 			TimelineItems timelineItemsConnection `graphql:"timelineItems(first: $timelineFirst, after: $timelineAfter)"`
@@ -81,22 +58,13 @@ type timelineQuery struct {
 	} `graphql:"node(id: $gqlNodeId)"`
 }
 
-func (q *timelineQuery) rateLimit() rateLimit {
-	return q.RateLimit
-}
-
 type commentEditQuery struct {
-	RateLimit rateLimit `graphql:"rateLimit(dryRun: $dryRun)"`
-	Node      struct {
+	Node struct {
 		Typename     githubv4.String `graphql:"__typename"`
 		IssueComment struct {
 			UserContentEdits userContentEditConnection `graphql:"userContentEdits(last: $commentEditLast, before: $commentEditBefore)"`
 		} `graphql:"... on IssueComment"`
 	} `graphql:"node(id: $gqlNodeId)"`
-}
-
-func (q *commentEditQuery) rateLimit() rateLimit {
-	return q.RateLimit
 }
 
 type user struct {


### PR DESCRIPTION
I wrote a new struct `client` which handles all the calls to the Github GraphQL API and which deals with the rate limit in a single place.

Note: work in progress; some manual testing is still needed.