### PR TITLE
Fix GitLab access tokens settings link

### DIFF
--- a/bridge/gitlab/config.go
+++ b/bridge/gitlab/config.go
@@ -194,7 +194,7 @@ func promptTokenOptions(repo repository.RepoKeyring, login, baseUrl string) (aut
 }
 
 func promptToken(baseUrl string) (*auth.Token, error) {
-	fmt.Printf("You can generate a new token by visiting %s.\n", strings.TrimSuffix(baseUrl, "/")+"/profile/personal_access_tokens")
+	fmt.Printf("You can generate a new token by visiting %s.\n", strings.TrimSuffix(baseUrl, "/")+"/-/profile/personal_access_tokens")
 	fmt.Println("Choose 'Create personal access token' and set the necessary access scope for your repository.")
 	fmt.Println()
 	fmt.Println("'api' access scope: to be able to make api calls")

--- a/bridge/gitlab/config.go
+++ b/bridge/gitlab/config.go
@@ -3,7 +3,6 @@ package gitlab
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -195,7 +194,7 @@ func promptTokenOptions(repo repository.RepoKeyring, login, baseUrl string) (aut
 }
 
 func promptToken(baseUrl string) (*auth.Token, error) {
-	fmt.Printf("You can generate a new token by visiting %s.\n", path.Join(baseUrl, "profile/personal_access_tokens"))
+	fmt.Printf("You can generate a new token by visiting %s.\n", strings.TrimSuffix(baseUrl, "/")+"/profile/personal_access_tokens")
 	fmt.Println("Choose 'Create personal access token' and set the necessary access scope for your repository.")
 	fmt.Println()
 	fmt.Println("'api' access scope: to be able to make api calls")


### PR DESCRIPTION
What's shown currently:

> You can generate a new token by visiting [https:/gitlab.com/profile/personal_access_tokens](https:/gitlab.com/profile/personal_access_tokens).