### PR TITLE
Fix: github bridge: push then pull without duplication

### DIFF
--- a/bridge/github/import.go
+++ b/bridge/github/import.go
@@ -184,7 +184,7 @@ func (gi *githubImporter) ensureIssue(ctx context.Context, repo *cache.RepoCache
 
 	// resolve bug
 	b, err := repo.ResolveBugMatcher(func(excerpt *cache.BugExcerpt) bool {
-		return excerpt.CreateMetadata[core.MetaKeyOrigin] == target &&
+		return excerpt.CreateMetadata[metaKeyGithubUrl] == issue.Url.String() &&
 			excerpt.CreateMetadata[metaKeyGithubId] == parseId(issue.Id)
 	})
 	if err == nil {


### PR DESCRIPTION
Fixes #690

Rationale: When we export the bug instance, we only set `githubID` and `githubURL` (bridge/github/export.go:469)