### PR TITLE
feat: enable configurable `LocalStorage` in `GoGitRepo`

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -14,7 +14,7 @@ import (
 	"github.com/MichaelMure/git-bug/util/interrupt"
 )
 
-const gitBugApplicationName = "git-bug"
+const gitBugNamespace = "git-bug"
 
 // Env is the environment of a command
 type Env struct {
@@ -56,7 +56,7 @@ func loadRepo(env *Env) func(*cobra.Command, []string) error {
 			return fmt.Errorf("unable to get the current working directory: %q", err)
 		}
 
-		env.repo, err = repository.OpenGoGitRepo(cwd, gitBugApplicationName, []repository.ClockLoader{bug.ClockLoader})
+		env.repo, err = repository.OpenGoGitRepo(cwd, gitBugNamespace, []repository.ClockLoader{bug.ClockLoader})
 		if err == repository.ErrNotARepo {
 			return fmt.Errorf("%s must be run from within a git repo", rootCommandName)
 		}

--- a/commands/env.go
+++ b/commands/env.go
@@ -14,6 +14,8 @@ import (
 	"github.com/MichaelMure/git-bug/util/interrupt"
 )
 
+const gitBugApplicationName = "git-bug"
+
 // Env is the environment of a command
 type Env struct {
 	repo    repository.ClockedRepo
@@ -54,7 +56,7 @@ func loadRepo(env *Env) func(*cobra.Command, []string) error {
 			return fmt.Errorf("unable to get the current working directory: %q", err)
 		}
 
-		env.repo, err = repository.OpenGoGitRepo(cwd, []repository.ClockLoader{bug.ClockLoader})
+		env.repo, err = repository.OpenGoGitRepo(cwd, gitBugApplicationName, []repository.ClockLoader{bug.ClockLoader})
 		if err == repository.ErrNotARepo {
 			return fmt.Errorf("%s must be run from within a git repo", rootCommandName)
 		}

--- a/entity/dag/example_test.go
+++ b/entity/dag/example_test.go
@@ -336,14 +336,15 @@ func Read(repo repository.ClockedRepo, id entity.Id) (*ProjectConfig, error) {
 }
 
 func Example_entity() {
+	const gitBugApplicationName = "git-bug"
 	// Note: this example ignore errors for readability
 	// Note: variable names get a little confusing as we are simulating both side in the same function
 
 	// Let's start by defining two git repository and connecting them as remote
 	repoRenePath, _ := os.MkdirTemp("", "")
 	repoIsaacPath, _ := os.MkdirTemp("", "")
-	repoRene, _ := repository.InitGoGitRepo(repoRenePath)
-	repoIsaac, _ := repository.InitGoGitRepo(repoIsaacPath)
+	repoRene, _ := repository.InitGoGitRepo(repoRenePath, gitBugApplicationName)
+	repoIsaac, _ := repository.InitGoGitRepo(repoIsaacPath, gitBugApplicationName)
 	_ = repoRene.AddRemote("origin", repoIsaacPath)
 	_ = repoIsaac.AddRemote("origin", repoRenePath)
 

--- a/entity/dag/example_test.go
+++ b/entity/dag/example_test.go
@@ -336,15 +336,15 @@ func Read(repo repository.ClockedRepo, id entity.Id) (*ProjectConfig, error) {
 }
 
 func Example_entity() {
-	const gitBugApplicationName = "git-bug"
+	const gitBugNamespace = "git-bug"
 	// Note: this example ignore errors for readability
 	// Note: variable names get a little confusing as we are simulating both side in the same function
 
 	// Let's start by defining two git repository and connecting them as remote
 	repoRenePath, _ := os.MkdirTemp("", "")
 	repoIsaacPath, _ := os.MkdirTemp("", "")
-	repoRene, _ := repository.InitGoGitRepo(repoRenePath, gitBugApplicationName)
-	repoIsaac, _ := repository.InitGoGitRepo(repoIsaacPath, gitBugApplicationName)
+	repoRene, _ := repository.InitGoGitRepo(repoRenePath, gitBugNamespace)
+	repoIsaac, _ := repository.InitGoGitRepo(repoIsaacPath, gitBugNamespace)
 	_ = repoRene.AddRemote("origin", repoIsaacPath)
 	_ = repoIsaac.AddRemote("origin", repoRenePath)
 

--- a/misc/random_bugs/cmd/main.go
+++ b/misc/random_bugs/cmd/main.go
@@ -11,7 +11,7 @@ import (
 // This program will randomly generate a collection of bugs in the repository
 // of the current path
 func main() {
-	const gitBugApplicationName = "git-bug"
+	const gitBugNamespace = "git-bug"
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -22,7 +22,7 @@ func main() {
 		bug.ClockLoader,
 	}
 
-	repo, err := repository.OpenGoGitRepo(dir, gitBugApplicationName, loaders)
+	repo, err := repository.OpenGoGitRepo(dir, gitBugNamespace, loaders)
 	if err != nil {
 		panic(err)
 	}

--- a/misc/random_bugs/cmd/main.go
+++ b/misc/random_bugs/cmd/main.go
@@ -11,6 +11,8 @@ import (
 // This program will randomly generate a collection of bugs in the repository
 // of the current path
 func main() {
+	const gitBugApplicationName = "git-bug"
+
 	dir, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -20,7 +22,7 @@ func main() {
 		bug.ClockLoader,
 	}
 
-	repo, err := repository.OpenGoGitRepo(dir, loaders)
+	repo, err := repository.OpenGoGitRepo(dir, gitBugApplicationName, loaders)
 	if err != nil {
 		panic(err)
 	}

--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -320,7 +320,6 @@ func (repo *GoGitRepo) GetBleveIndex(name string) (bleve.Index, error) {
 		return index, nil
 	}
 
-	// path := filepath.Join(repo.path, "git-bug", "indexes", name)
 	path := filepath.Join(repo.localStorage.Root(), indexPath, name)
 
 	index, err := bleve.Open(path)
@@ -352,7 +351,6 @@ func (repo *GoGitRepo) ClearBleveIndex(name string) error {
 	repo.indexesMutex.Lock()
 	defer repo.indexesMutex.Unlock()
 
-	// path := filepath.Join(repo.path, "git-bug", "indexes", name)
 	path := filepath.Join(repo.localStorage.Root(), indexPath, name)
 
 	err := os.RemoveAll(path)
@@ -794,7 +792,6 @@ func (repo *GoGitRepo) AllClocks() (map[string]lamport.Clock, error) {
 
 	result := make(map[string]lamport.Clock)
 
-	// files, err := ioutil.ReadDir(filepath.Join(repo.path, "git-bug", clockPath))
 	files, err := ioutil.ReadDir(filepath.Join(repo.localStorage.Root(), clockPath))
 	if os.IsNotExist(err) {
 		return nil, nil

--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -50,11 +50,11 @@ type GoGitRepo struct {
 	localStorage billy.Filesystem
 }
 
-// OpenGoGitRepo opens an already existing repo at the given path and with
-// the specified application name.  Given a repository path of "~/myrepo"
-// and an application name of "git-bug", local storage for the application
-// will be configured at "~/myrepo/.git/git-bug".
-func OpenGoGitRepo(path, application string, clockLoaders []ClockLoader) (*GoGitRepo, error) {
+// OpenGoGitRepo opens an already existing repo at the given path and
+// with the specified LocalStorage namespace.  Given a repository path
+// of "~/myrepo" and a namespace of "git-bug", local storage for the
+// GoGitRepo will be configured at "~/myrepo/.git/git-bug".
+func OpenGoGitRepo(path, namespace string, clockLoaders []ClockLoader) (*GoGitRepo, error) {
 	path, err := detectGitPath(path)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func OpenGoGitRepo(path, application string, clockLoaders []ClockLoader) (*GoGit
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, application)),
+		localStorage: osfs.New(filepath.Join(path, namespace)),
 	}
 
 	for _, loader := range clockLoaders {
@@ -98,11 +98,11 @@ func OpenGoGitRepo(path, application string, clockLoaders []ClockLoader) (*GoGit
 	return repo, nil
 }
 
-// InitGoGitRepo creates a new empty git repo at the given path and with
-// the specified application name.  Given a repository path of "~/myrepo"
-// and an application name of "git-bug", local storage for the application
-// will be configured at "~/myrepo/.git/git-bug".
-func InitGoGitRepo(path, application string) (*GoGitRepo, error) {
+// InitGoGitRepo creates a new empty git repo at the given path and
+// with the specified LocalStorage namespace.  Given a repository path
+// of "~/myrepo" and a namespace of "git-bug", local storage for the
+// GoGitRepo will be configured at "~/myrepo/.git/git-bug".
+func InitGoGitRepo(path, namespace string) (*GoGitRepo, error) {
 	r, err := gogit.PlainInit(path, false)
 	if err != nil {
 		return nil, err
@@ -119,15 +119,15 @@ func InitGoGitRepo(path, application string) (*GoGitRepo, error) {
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, ".git", application)),
+		localStorage: osfs.New(filepath.Join(path, ".git", namespace)),
 	}, nil
 }
 
-// InitBareGoGitRepo creates a new --bare empty git repo at the given path
-// and with the specified application name.  Given a repository path of
-// "~/myrepo" and an application name of "git-bug", local storage for the
-// application will be configured at "~/myrepo/.git/git-bug".
-func InitBareGoGitRepo(path, application string) (*GoGitRepo, error) {
+// InitBareGoGitRepo creates a new --bare empty git repo at the given
+// path and with the specified LocalStorage namespace.  Given a repository
+// path of "~/myrepo" and a namespace of "git-bug", local storage for the
+// GoGitRepo will be configured at "~/myrepo/.git/git-bug".
+func InitBareGoGitRepo(path, namespace string) (*GoGitRepo, error) {
 	r, err := gogit.PlainInit(path, true)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func InitBareGoGitRepo(path, application string) (*GoGitRepo, error) {
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, application)),
+		localStorage: osfs.New(filepath.Join(path, namespace)),
 	}, nil
 }
 
@@ -306,7 +306,7 @@ func (repo *GoGitRepo) GetRemotes() (map[string]string, error) {
 }
 
 // LocalStorage returns a billy.Filesystem giving access to
-// $RepoPath/.git/$ApplicationName.
+// $RepoPath/.git/$Namespace.
 func (repo *GoGitRepo) LocalStorage() billy.Filesystem {
 	return repo.localStorage
 }

--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -26,6 +26,7 @@ import (
 )
 
 const clockPath = "clocks"
+const indexPath = "indexes"
 
 var _ ClockedRepo = &GoGitRepo{}
 var _ TestedRepo = &GoGitRepo{}
@@ -49,8 +50,11 @@ type GoGitRepo struct {
 	localStorage billy.Filesystem
 }
 
-// OpenGoGitRepo open an already existing repo at the given path
-func OpenGoGitRepo(path string, clockLoaders []ClockLoader) (*GoGitRepo, error) {
+// OpenGoGitRepo opens an already existing repo at the given path and with
+// the specified application name.  Given a repository path of "~/myrepo"
+// and an application name of "git-bug", local storage for the application
+// will be configured at "~/myrepo/.git/git-bug".
+func OpenGoGitRepo(path, application string, clockLoaders []ClockLoader) (*GoGitRepo, error) {
 	path, err := detectGitPath(path)
 	if err != nil {
 		return nil, err
@@ -72,7 +76,7 @@ func OpenGoGitRepo(path string, clockLoaders []ClockLoader) (*GoGitRepo, error) 
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, "git-bug")),
+		localStorage: osfs.New(filepath.Join(path, application)),
 	}
 
 	for _, loader := range clockLoaders {
@@ -94,8 +98,11 @@ func OpenGoGitRepo(path string, clockLoaders []ClockLoader) (*GoGitRepo, error) 
 	return repo, nil
 }
 
-// InitGoGitRepo create a new empty git repo at the given path
-func InitGoGitRepo(path string) (*GoGitRepo, error) {
+// InitGoGitRepo creates a new empty git repo at the given path and with
+// the specified application name.  Given a repository path of "~/myrepo"
+// and an application name of "git-bug", local storage for the application
+// will be configured at "~/myrepo/.git/git-bug".
+func InitGoGitRepo(path, application string) (*GoGitRepo, error) {
 	r, err := gogit.PlainInit(path, false)
 	if err != nil {
 		return nil, err
@@ -112,12 +119,15 @@ func InitGoGitRepo(path string) (*GoGitRepo, error) {
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, ".git", "git-bug")),
+		localStorage: osfs.New(filepath.Join(path, ".git", application)),
 	}, nil
 }
 
-// InitBareGoGitRepo create a new --bare empty git repo at the given path
-func InitBareGoGitRepo(path string) (*GoGitRepo, error) {
+// InitBareGoGitRepo creates a new --bare empty git repo at the given path
+// and with the specified application name.  Given a repository path of
+// "~/myrepo" and an application name of "git-bug", local storage for the
+// application will be configured at "~/myrepo/.git/git-bug".
+func InitBareGoGitRepo(path, application string) (*GoGitRepo, error) {
 	r, err := gogit.PlainInit(path, true)
 	if err != nil {
 		return nil, err
@@ -134,7 +144,7 @@ func InitBareGoGitRepo(path string) (*GoGitRepo, error) {
 		clocks:       make(map[string]lamport.Clock),
 		indexes:      make(map[string]bleve.Index),
 		keyring:      k,
-		localStorage: osfs.New(filepath.Join(path, "git-bug")),
+		localStorage: osfs.New(filepath.Join(path, application)),
 	}, nil
 }
 
@@ -295,7 +305,8 @@ func (repo *GoGitRepo) GetRemotes() (map[string]string, error) {
 	return result, nil
 }
 
-// LocalStorage return a billy.Filesystem giving access to $RepoPath/.git/git-bug
+// LocalStorage returns a billy.Filesystem giving access to
+// $RepoPath/.git/$ApplicationName.
 func (repo *GoGitRepo) LocalStorage() billy.Filesystem {
 	return repo.localStorage
 }
@@ -309,7 +320,8 @@ func (repo *GoGitRepo) GetBleveIndex(name string) (bleve.Index, error) {
 		return index, nil
 	}
 
-	path := filepath.Join(repo.path, "git-bug", "indexes", name)
+	// path := filepath.Join(repo.path, "git-bug", "indexes", name)
+	path := filepath.Join(repo.localStorage.Root(), indexPath, name)
 
 	index, err := bleve.Open(path)
 	if err == nil {
@@ -340,7 +352,8 @@ func (repo *GoGitRepo) ClearBleveIndex(name string) error {
 	repo.indexesMutex.Lock()
 	defer repo.indexesMutex.Unlock()
 
-	path := filepath.Join(repo.path, "git-bug", "indexes", name)
+	// path := filepath.Join(repo.path, "git-bug", "indexes", name)
+	path := filepath.Join(repo.localStorage.Root(), indexPath, name)
 
 	err := os.RemoveAll(path)
 	if err != nil {
@@ -781,7 +794,8 @@ func (repo *GoGitRepo) AllClocks() (map[string]lamport.Clock, error) {
 
 	result := make(map[string]lamport.Clock)
 
-	files, err := ioutil.ReadDir(filepath.Join(repo.path, "git-bug", clockPath))
+	// files, err := ioutil.ReadDir(filepath.Join(repo.path, "git-bug", clockPath))
+	files, err := ioutil.ReadDir(filepath.Join(repo.localStorage.Root(), clockPath))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}

--- a/repository/gogit_test.go
+++ b/repository/gogit_test.go
@@ -17,7 +17,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(plainRoot)
 
-	_, err = InitGoGitRepo(plainRoot)
+	_, err = InitGoGitRepo(plainRoot, testApplicationName)
 	require.NoError(t, err)
 	plainGitDir := filepath.Join(plainRoot, ".git")
 
@@ -26,7 +26,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(bareRoot)
 
-	_, err = InitBareGoGitRepo(bareRoot)
+	_, err = InitBareGoGitRepo(bareRoot, testApplicationName)
 	require.NoError(t, err)
 	bareGitDir := bareRoot
 
@@ -52,7 +52,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		r, err := OpenGoGitRepo(tc.inPath, nil)
+		r, err := OpenGoGitRepo(tc.inPath, testApplicationName, nil)
 
 		if tc.err {
 			require.Error(t, err, i)

--- a/repository/gogit_test.go
+++ b/repository/gogit_test.go
@@ -72,10 +72,15 @@ func TestGoGitRepo_Indexes(t *testing.T) {
 
 	plainRoot, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	// defer os.RemoveAll(plainRoot)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(plainRoot))
+	})
 
 	repo, err := InitGoGitRepo(plainRoot, namespace)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, repo.Close())
+	})
 
 	// Can create indices
 	indexA, err := repo.GetBleveIndex("a")

--- a/repository/gogit_test.go
+++ b/repository/gogit_test.go
@@ -17,7 +17,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(plainRoot)
 
-	_, err = InitGoGitRepo(plainRoot, testApplicationName)
+	_, err = InitGoGitRepo(plainRoot, namespace)
 	require.NoError(t, err)
 	plainGitDir := filepath.Join(plainRoot, ".git")
 
@@ -26,7 +26,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(bareRoot)
 
-	_, err = InitBareGoGitRepo(bareRoot, testApplicationName)
+	_, err = InitBareGoGitRepo(bareRoot, namespace)
 	require.NoError(t, err)
 	bareGitDir := bareRoot
 
@@ -52,7 +52,7 @@ func TestNewGoGitRepo(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		r, err := OpenGoGitRepo(tc.inPath, testApplicationName, nil)
+		r, err := OpenGoGitRepo(tc.inPath, namespace, nil)
 
 		if tc.err {
 			require.Error(t, err, i)
@@ -65,4 +65,37 @@ func TestNewGoGitRepo(t *testing.T) {
 
 func TestGoGitRepo(t *testing.T) {
 	RepoTest(t, CreateGoGitTestRepo, CleanupTestRepos)
+}
+
+func TestGoGitRepo_Indexes(t *testing.T) {
+	t.Parallel()
+
+	plainRoot, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	// defer os.RemoveAll(plainRoot)
+
+	repo, err := InitGoGitRepo(plainRoot, namespace)
+	require.NoError(t, err)
+
+	// Can create indices
+	indexA, err := repo.GetBleveIndex("a")
+	require.NoError(t, err)
+	require.NotZero(t, indexA)
+	require.FileExists(t, filepath.Join(plainRoot, ".git", namespace, "indexes", "a", "index_meta.json"))
+	require.FileExists(t, filepath.Join(plainRoot, ".git", namespace, "indexes", "a", "store"))
+
+	indexB, err := repo.GetBleveIndex("b")
+	require.NoError(t, err)
+	require.NotZero(t, indexB)
+	require.DirExists(t, filepath.Join(plainRoot, ".git", namespace, "indexes", "b"))
+
+	// Can get an existing index
+	indexA, err = repo.GetBleveIndex("a")
+	require.NoError(t, err)
+	require.NotZero(t, indexA)
+
+	// Can delete an index
+	err = repo.ClearBleveIndex("a")
+	require.NoError(t, err)
+	require.NoDirExists(t, filepath.Join(plainRoot, ".git", namespace, "indexes", "a"))
 }

--- a/repository/gogit_testing.go
+++ b/repository/gogit_testing.go
@@ -7,7 +7,7 @@ import (
 	"github.com/99designs/keyring"
 )
 
-const testApplicationName = "git-bug"
+const namespace = "git-bug"
 
 // This is intended for testing only
 
@@ -25,7 +25,7 @@ func CreateGoGitTestRepo(bare bool) TestedRepo {
 		creator = InitGoGitRepo
 	}
 
-	repo, err := creator(dir, testApplicationName)
+	repo, err := creator(dir, namespace)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/repository/gogit_testing.go
+++ b/repository/gogit_testing.go
@@ -7,6 +7,8 @@ import (
 	"github.com/99designs/keyring"
 )
 
+const testApplicationName = "git-bug"
+
 // This is intended for testing only
 
 func CreateGoGitTestRepo(bare bool) TestedRepo {
@@ -15,7 +17,7 @@ func CreateGoGitTestRepo(bare bool) TestedRepo {
 		log.Fatal(err)
 	}
 
-	var creator func(string) (*GoGitRepo, error)
+	var creator func(string, string) (*GoGitRepo, error)
 
 	if bare {
 		creator = InitBareGoGitRepo
@@ -23,7 +25,7 @@ func CreateGoGitTestRepo(bare bool) TestedRepo {
 		creator = InitGoGitRepo
 	}
 
-	repo, err := creator(dir)
+	repo, err := creator(dir, testApplicationName)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
As noted in https://github.com/MichaelMure/git-bug/issues/704#issuecomment-1134822739 and further described in https://github.com/MichaelMure/git-bug/issues/797, this PR changes the functions that return a `GoGitRepo` to accept an additional `applicationName` parameter so that the directory containing the repository's `LocalStorage` folder is configurable.