### PR TITLE
graphql: fix two invalid mutex lock leading to data races

### DIFF
--- a/api/graphql/models/lazy_bug.go
+++ b/api/graphql/models/lazy_bug.go
@@ -49,12 +49,12 @@ func NewLazyBug(cache *cache.RepoCache, excerpt *cache.BugExcerpt) *lazyBug {
 }
 
 func (lb *lazyBug) load() error {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
 	if lb.snap != nil {
 		return nil
 	}
-
-	lb.mu.Lock()
-	defer lb.mu.Unlock()
 
 	b, err := lb.cache.ResolveBug(lb.excerpt.Id)
 	if err != nil {

--- a/api/graphql/models/lazy_identity.go
+++ b/api/graphql/models/lazy_identity.go
@@ -41,12 +41,12 @@ func NewLazyIdentity(cache *cache.RepoCache, excerpt *cache.IdentityExcerpt) *la
 }
 
 func (li *lazyIdentity) load() (*cache.IdentityCache, error) {
+	li.mu.Lock()
+	defer li.mu.Unlock()
+
 	if li.id != nil {
 		return li.id, nil
 	}
-
-	li.mu.Lock()
-	defer li.mu.Unlock()
 
 	id, err := li.cache.ResolveIdentity(li.excerpt.Id)
 	if err != nil {


### PR DESCRIPTION
Fix one the issue mentioned in https://github.com/MichaelMure/git-bug/issues/810