### PR TITLE
fix(810): close context to exit loop blocked by race in bridge/github package

### DIFF
--- a/bridge/github/import_mediator.go
+++ b/bridge/github/import_mediator.go
@@ -89,6 +89,7 @@ func NewImportMediator(ctx context.Context, client *rateLimitHandlerClient, owne
 	}
 	go func() {
 		mm.fillImportEvents(ctx)
+		ctx.Done()
 		close(mm.importEvents)
 	}()
 	return &mm


### PR DESCRIPTION
This solution to closing the otherwise blocked thread is to call `Done()` on it's `Context` which allows blocked go routine to end cleanly.