### PR TITLE
Added QuietFormatter output

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -91,7 +91,7 @@ git bug ls status:open --by creation "foo bar" baz
 		"Select the sorting direction. Valid values are [asc,desc]")
 	cmd.RegisterFlagCompletionFunc("direction", completeFrom([]string{"asc", "desc"}))
 	flags.StringVarP(&options.outputFormat, "format", "f", "default",
-		"Select the output formatting style. Valid values are [default,plain,json,org-mode]")
+		"Select the output formatting style. Valid values are [default,plain,quiet,json,org-mode]")
 	cmd.RegisterFlagCompletionFunc("format",
 		completeFrom([]string{"default", "plain", "json", "org-mode"}))
 
@@ -138,6 +138,8 @@ func runLs(env *Env, opts lsOptions, args []string) error {
 		return lsOrgmodeFormatter(env, bugExcerpt)
 	case "plain":
 		return lsPlainFormatter(env, bugExcerpt)
+	case "quiet":
+		return lsQuietFormatter(env, bugExcerpt)
 	case "json":
 		return lsJsonFormatter(env, bugExcerpt)
 	case "compact":
@@ -293,6 +295,13 @@ func lsDefaultFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 func lsPlainFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 	for _, b := range bugExcerpts {
 		env.out.Printf("%s [%s] %s\n", b.Id.Human(), b.Status, strings.TrimSpace(b.Title))
+	}
+	return nil
+}
+
+func lsQuietFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
+	for _, b := range bugExcerpts {
+		env.out.Printf("%s\n", b.Id.Human())
 	}
 	return nil
 }


### PR DESCRIPTION
QuietFormatter prints only the bug ID, similarly to how 'docker ls --quiet' works.
This mode is very useful for making batch changes to bugs using bash loops.
You can use the output of any query to easily batch add/remove labels, comments etc.

For example, the bash line below adds the label 'newLabel' to all bugs.
``for item in `git bug ls -f quiet`; do git bug label add $item newLabel; done``