### PR TITLE
feat(836): updates default `ls` formatter for TSV output

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -279,7 +279,7 @@ func lsDefaultFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 			comments = "  ∞ 💬"
 		}
 
-		env.out.Printf("%s %s\t%s\t%s\t%s\n",
+		env.out.Printf("%s\t%s\t%s\t%s\t%s\n",
 			colors.Cyan(b.Id.Human()),
 			colors.Yellow(b.Status),
 			titleFmt+labelsFmt,

--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -74,12 +74,11 @@ $`
 		name := fmt.Sprintf("with %s format", testcase.format)
 
 		t.Run(name, func(t *testing.T) {
-			env, _, _ := newTestEnvAndBug(t)
+			env, _ := newTestEnvAndBug(t)
 
 			require.NoError(t, runLs(env.env, opts, []string{}))
 			t.Log(env.out.String())
 			require.Regexp(t, testcase.exp, env.out.String())
-			require.Equal(t, "", env.err.String())
 		})
 	}
 
@@ -90,13 +89,12 @@ $`
 			outputFormat:  "json",
 		}
 
-		env, _, _ := newTestEnvAndBug(t)
+		env, _ := newTestEnvAndBug(t)
 
 		require.NoError(t, runLs(env.env, opts, []string{}))
 
 		bugs := []JSONBugExcerpt{}
 		require.NoError(t, json.Unmarshal(env.out.Bytes(), &bugs))
-		require.Empty(t, env.err.Bytes())
 
 		require.Len(t, bugs, 1)
 	})

--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,4 +42,62 @@ func Test_repairQuery(t *testing.T) {
 	for _, tc := range cases {
 		require.Equal(t, tc.output, repairQuery(tc.args))
 	}
+}
+
+func TestLs_Format(t *testing.T) {
+	const expOrgMode = `^#+TODO: OPEN | CLOSED
+[*] OPEN   [0-9a-f]{7} \[\d\d\d\d-\d\d-\d\d [[:alpha:]]{3} \d\d:\d\d\] John Doe: this is a bug title ::
+[*]{2} Last Edited: \[\d\d\d\d-\d\d-\d\d [[:alpha:]]{3} \d\d:\d\d\]
+[*]{2} Actors:
+: [0-9a-f]{7} John Doe
+[*]{2} Participants:
+: [0-9a-f]{7} John Doe
+$`
+
+	cases := []struct {
+		format string
+		exp    string
+	}{
+		{"default", "^[0-9a-f]{7}\topen\tthis is a bug title                               \tJohn Doe       \t\n$"},
+		{"plain", "^[0-9a-f]{7} \\[open\\] this is a bug title\n$"},
+		{"compact", "^[0-9a-f]{7} open this is a bug title                            John Doe\n$"},
+		{"org-mode", expOrgMode},
+	}
+
+	for _, testcase := range cases {
+		opts := lsOptions{
+			sortDirection: "asc",
+			sortBy:        "creation",
+			outputFormat:  testcase.format,
+		}
+
+		name := fmt.Sprintf("with %s format", testcase.format)
+
+		t.Run(name, func(t *testing.T) {
+			env, _, _ := newTestEnvAndBug(t)
+
+			require.NoError(t, runLs(env.env, opts, []string{}))
+			t.Log(env.out.String())
+			require.Regexp(t, testcase.exp, env.out.String())
+			require.Equal(t, "", env.err.String())
+		})
+	}
+
+	t.Run("with JSON format", func(t *testing.T) {
+		opts := lsOptions{
+			sortDirection: "asc",
+			sortBy:        "creation",
+			outputFormat:  "json",
+		}
+
+		env, _, _ := newTestEnvAndBug(t)
+
+		require.NoError(t, runLs(env.env, opts, []string{}))
+
+		bugs := []JSONBugExcerpt{}
+		require.NoError(t, json.Unmarshal(env.out.Bytes(), &bugs))
+		require.Empty(t, env.err.Bytes())
+
+		require.Len(t, bugs, 1)
+	})
 }


### PR DESCRIPTION
This change results in no (visible) change to the `ls` command's default formatter - the single space separating the bug prefix from the state is simply replaced by a tab (which will also position the state in the ninth column when tab widths are 2, 4 or 8 spaces.  Output from the command will be formatted as follows:

```
smoyer1@xps-15-7:~/git/git-bug$ git bug ls | head
f509b69 closed  CLI UX need refinements                      ◼ ◼ ◼      Alexandre Fran…  17 💬
8310415 closed  Serialization format                           ◼ ◼      Michael Muré (…  26 💬
0e2428a closed  Graphql schema is not documented                 ◼      Michael Muré (…
cd6935a closed  feat: Github import                          ◼ ◼ ◼      Michael Muré (…  35 💬
3dbe3bc open    feat: git-bug should store metadata for com… ◼ ◼ ◼      Michael Muré (…   1 💬
73441f2 open    Support for forking and then PR ?                ◼      Deleted user (…   7 💬
a2e9271 open    feat: media-embedding in messages            ◼ ◼ ◼      Michael Muré (…   2 💬
ef31717 open    feat: configuration for the default remote ◼ ◼ ◼ ◼      Michael Muré (…
bc0bf1d open    feat: render comments as Markdown              ◼ ◼      Michael Muré (…  10 💬
1dafa62 closed  termui crashes on blank bug                             esell (esell)     1 💬
```

Resolves #836