### PR TITLE
feat(530): make label commands consistent

### DIFF
--- a/commands/label.go
+++ b/commands/label.go
@@ -20,13 +20,14 @@ func newLabelCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newLabelAddCommand())
+	cmd.AddCommand(newLabelLsCommand())
 	cmd.AddCommand(newLabelRmCommand())
 
 	return cmd
 }
 
 func runLabel(env *Env, args []string) error {
-	b, args, err := _select.ResolveBug(env.backend, args)
+	b, _, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
 		return err
 	}

--- a/commands/label_ls.go
+++ b/commands/label_ls.go
@@ -4,11 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newLsLabelCommand() *cobra.Command {
+func newLabelLsCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:   "ls-label",
+		Use:   "ls",
 		Short: "List valid labels.",
 		Long: `List valid labels.
 
@@ -17,13 +17,17 @@ Note: in the future, a proper label policy could be implemented where valid labe
 		RunE: closeBackend(env, func(cmd *cobra.Command, args []string) error {
 			return runLabelLs(env)
 		}),
-		Deprecated: ` and will be removed in v1.0.
-
-The functionality provided by this command is now provided by
-the following (equivalent) command:
-git-bug label ls
-`,
 	}
 
 	return cmd
+}
+
+func runLabelLs(env *Env) error {
+	labels := env.backend.ValidLabels()
+
+	for _, l := range labels {
+		env.out.Println(l)
+	}
+
+	return nil
 }

--- a/doc/man/git-bug-label-ls.1
+++ b/doc/man/git-bug-label-ls.1
@@ -3,12 +3,12 @@
 
 .SH NAME
 .PP
-git-bug-ls-label - List valid labels.
+git-bug-label-ls - List valid labels.
 
 
 .SH SYNOPSIS
 .PP
-\fBgit-bug ls-label [flags]\fP
+\fBgit-bug label ls [flags]\fP
 
 
 .SH DESCRIPTION
@@ -22,9 +22,9 @@ Note: in the future, a proper label policy could be implemented where valid labe
 .SH OPTIONS
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for ls-label
+	help for ls
 
 
 .SH SEE ALSO
 .PP
-\fBgit-bug(1)\fP
+\fBgit-bug-label(1)\fP

--- a/doc/man/git-bug-label.1
+++ b/doc/man/git-bug-label.1
@@ -24,4 +24,4 @@ Display, add or remove labels to/from a bug.
 
 .SH SEE ALSO
 .PP
-\fBgit-bug(1)\fP, \fBgit-bug-label-add(1)\fP, \fBgit-bug-label-rm(1)\fP
+\fBgit-bug(1)\fP, \fBgit-bug-label-add(1)\fP, \fBgit-bug-label-ls(1)\fP, \fBgit-bug-label-rm(1)\fP

--- a/doc/man/git-bug.1
+++ b/doc/man/git-bug.1
@@ -29,4 +29,4 @@ the same git remote you are already using to collaborate with other people.
 
 .SH SEE ALSO
 .PP
-\fBgit-bug-add(1)\fP, \fBgit-bug-bridge(1)\fP, \fBgit-bug-commands(1)\fP, \fBgit-bug-comment(1)\fP, \fBgit-bug-deselect(1)\fP, \fBgit-bug-label(1)\fP, \fBgit-bug-ls(1)\fP, \fBgit-bug-ls-label(1)\fP, \fBgit-bug-pull(1)\fP, \fBgit-bug-push(1)\fP, \fBgit-bug-rm(1)\fP, \fBgit-bug-select(1)\fP, \fBgit-bug-show(1)\fP, \fBgit-bug-status(1)\fP, \fBgit-bug-termui(1)\fP, \fBgit-bug-title(1)\fP, \fBgit-bug-user(1)\fP, \fBgit-bug-version(1)\fP, \fBgit-bug-webui(1)\fP
+\fBgit-bug-add(1)\fP, \fBgit-bug-bridge(1)\fP, \fBgit-bug-commands(1)\fP, \fBgit-bug-comment(1)\fP, \fBgit-bug-deselect(1)\fP, \fBgit-bug-label(1)\fP, \fBgit-bug-ls(1)\fP, \fBgit-bug-pull(1)\fP, \fBgit-bug-push(1)\fP, \fBgit-bug-rm(1)\fP, \fBgit-bug-select(1)\fP, \fBgit-bug-show(1)\fP, \fBgit-bug-status(1)\fP, \fBgit-bug-termui(1)\fP, \fBgit-bug-title(1)\fP, \fBgit-bug-user(1)\fP, \fBgit-bug-version(1)\fP, \fBgit-bug-webui(1)\fP

--- a/doc/md/git-bug.md
+++ b/doc/md/git-bug.md
@@ -31,7 +31,6 @@ git-bug [flags]
 * [git-bug deselect](git-bug_deselect.md)	 - Clear the implicitly selected bug.
 * [git-bug label](git-bug_label.md)	 - Display, add or remove labels to/from a bug.
 * [git-bug ls](git-bug_ls.md)	 - List bugs.
-* [git-bug ls-label](git-bug_ls-label.md)	 - List valid labels.
 * [git-bug pull](git-bug_pull.md)	 - Pull bugs update from a git remote.
 * [git-bug push](git-bug_push.md)	 - Push bugs update to a git remote.
 * [git-bug rm](git-bug_rm.md)	 - Remove an existing bug.

--- a/doc/md/git-bug_label.md
+++ b/doc/md/git-bug_label.md
@@ -16,5 +16,6 @@ git-bug label [ID] [flags]
 
 * [git-bug](git-bug.md)	 - A bug tracker embedded in Git.
 * [git-bug label add](git-bug_label_add.md)	 - Add a label to a bug.
+* [git-bug label ls](git-bug_label_ls.md)	 - List valid labels.
 * [git-bug label rm](git-bug_label_rm.md)	 - Remove a label from a bug.
 

--- a/doc/md/git-bug_label_ls.md
+++ b/doc/md/git-bug_label_ls.md
@@ -1,4 +1,4 @@
-## git-bug ls-label
+## git-bug label ls
 
 List valid labels.
 
@@ -9,16 +9,16 @@ List valid labels.
 Note: in the future, a proper label policy could be implemented where valid labels are defined in a configuration file. Until that, the default behavior is to return the list of labels already used.
 
 ```
-git-bug ls-label [flags]
+git-bug label ls [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for ls-label
+  -h, --help   help for ls
 ```
 
 ### SEE ALSO
 
-* [git-bug](git-bug.md)	 - A bug tracker embedded in Git.
+* [git-bug label](git-bug_label.md)	 - Display, add or remove labels to/from a bug.
 


### PR DESCRIPTION
The discussion in #530 surrounding reorganizing the `git-bug` commands around the various entities that are defined (bug, board, pr, user, etc) isn't finished but the idea of changing the command to `git-bug label ls`list the valid labels to `git-bug label ls` still has merit:

This form is consistent with how the other sub-commands are structure and eliminates the last hyphenated command.  Whether or not, #530 moves forward, I think this syntax makes sense.

Note that the `git-bug ls-label` command has been deprecated in the same way as `ls-id` (with a notice that it will be removed for v1.0.