### PR TITLE
doc/README: normalize verb tense and fix typo

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,14 +2,14 @@
 
 ## For users
 
-- [data model](model.md) describe how the data model works and why.
-- [query language](queries.md) describe git-bug's query language.
+- [data model](model.md) describes how the data model works and why.
+- [query language](queries.md) describes git-bug's query language.
 - [How-to: Read and edit offline your Github/Gitlab/Jira issues with git-bug](howto-github.md)
 
 ## For developers
 
-- :exclamation: [data model](model.md) describe how the data model works and why.
+- :exclamation: [data model](model.md) describes how the data model works and why.
 - :exclamation: [internal bird-view](architecture.md) gives an overview of the project architecture.
-- :exclamation: [Entity/DAG](../entity/dag/example_test.go) explain how to easily make your own distributed entity in git. 
-- [query language](queries.md) describe git-bug's query language.
-- [JIRA bridge de v notes](jira_bridge.md)
+- :exclamation: [Entity/DAG](../entity/dag/example_test.go) explains how to easily make your own distributed entity in git. 
+- [query language](queries.md) describes git-bug's query language.
+- [JIRA bridge dev notes](jira_bridge.md)


### PR DESCRIPTION
Just a small update to make the entry descriptions more consistent and readable.