### PR TITLE
fix(TestCache): eliminate hanging Windows tests

### DIFF
--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -130,6 +130,13 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.Bugs().ResolvePrefix(bug1.Id().String()[:10])
 	require.NoError(t, err)
+
+	// Close
+	require.NoError(t, cache.Close())
+	require.Empty(t, cache.bugs.cached)
+	require.Empty(t, cache.bugs.excerpts)
+	require.Empty(t, cache.identities.cached)
+	require.Empty(t, cache.identities.excerpts)
 }
 
 func TestCachePushPull(t *testing.T) {


### PR DESCRIPTION
As seen on PR #933 and others, it's common for the Windows test suite to fail when run via GitHub Actions.  In that PR, @zinderic also noted that it's less prevalent but can also occur on Mac OSX.

I can't test on Mac OSX but on the `ext4` file system, the `TempDir` is deleted but it's asynchronous and only occurs when there are no open file handles (when the `go test ./...` ends).  On Windows, removing the temporary directory is (more?) synchronous and so Go waits for the OS to remove the `TempDir` while the OS is waiting for the open file handlers to be closed.

As seen in the changed file, the solution is to explicitly close both instances of the cache as soon as they're no longer needed.  I don't quite understand why the other cache tests don't have this problem but my intuition says that the tests would run faster if those caches were also explicitly closed.

I'm considering refactoring these tests a bit so that there's a `t.Helper()` to create and clean-up the caches being tested - what do you think?