### PR TITLE
added EventMentionedInCommit

### DIFF
--- a/bridge/gitlab/event.go
+++ b/bridge/gitlab/event.go
@@ -40,6 +40,7 @@ const (
 	EventRemoveLabel
 	EventMentionedInIssue
 	EventMentionedInMergeRequest
+	EventMentionedInCommit
 )
 
 var _ Event = &NoteEvent{}
@@ -96,6 +97,9 @@ func (n NoteEvent) Kind() EventKind {
 
 	case strings.HasPrefix(n.Body, "mentioned in merge request"):
 		return EventMentionedInMergeRequest
+
+	case strings.HasPrefix(n.Body, "mentioned in commit"):
+		return EventMentionedInCommit
 
 	default:
 		return EventUnknown

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -324,7 +324,8 @@ func (gi *gitlabImporter) ensureIssueEvent(repo *cache.RepoCache, b *cache.BugCa
 		EventLocked,
 		EventUnlocked,
 		EventMentionedInIssue,
-		EventMentionedInMergeRequest:
+		EventMentionedInMergeRequest,
+		EventMentionedInCommit:
 
 		return nil
 


### PR DESCRIPTION
Added the event **EventMentionedInCommit** in the gitlab bridge to support / not give an error on events in gitlab issue s where an issue ID is mentioned in a commit message.

See issue #973

