### PR TITLE
Fixed version info be set when go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: build
 
+GIT_COMMIT:=$(shell git rev-parse --short HEAD)
+GIT_LAST_TAG:=$(shell git describe --dirty --tags)
+GIT_EXACT_TAG:=$(shell git name-rev --name-only --tags HEAD)
 UNAME_S := $(shell uname -s)
 XARGS:=xargs -r
 ifeq ($(UNAME_S),Darwin)
@@ -7,27 +10,30 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 COMMANDS_PATH:=github.com/MichaelMure/git-bug/commands
+LDFLAGS:=-X ${COMMANDS_PATH}.GitCommit=${GIT_COMMIT} \
+	-X ${COMMANDS_PATH}.GitLastTag=${GIT_LAST_TAG} \
+	-X ${COMMANDS_PATH}.GitExactTag=${GIT_EXACT_TAG}
 
 .PHONY: build
 build:
 	go generate
-	go build .
+	go build -ldflags "$(LDFLAGS)" .
 
 # produce a build debugger friendly
 .PHONY: debug-build
 debug-build:
 	go generate
-	go build -gcflags=all="-N -l" .
+	go build -ldflags "$(LDFLAGS)" -gcflags=all="-N -l" .
 
 .PHONY: install
 install:
 	go generate
-	go install .
+	go install -ldflags "$(LDFLAGS)" .
 
 .PHONY: releases
 releases:
 	go generate
-	go run github.com/mitchellh/gox@v1.0.1 -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	go run github.com/mitchellh/gox@v1.0.1 -ldflags "$(LDFLAGS)" -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 secure: secure-practices secure-vulnerabilities
 
@@ -56,7 +62,7 @@ pack-webui:
 # produce a build that will fetch the web UI from the filesystem instead of from the binary
 .PHONY: debug-webui
 debug-webui:
-	go build -tags=debugwebui
+	go build -ldflags "$(LDFLAGS)" -tags=debugwebui
 
 .PHONY: clean-local-bugs
 clean-local-bugs:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 all: build
 
-GIT_COMMIT:=$(shell git rev-list -1 HEAD)
-GIT_LAST_TAG:=$(shell git describe --abbrev=0 --tags)
-GIT_EXACT_TAG:=$(shell git name-rev --name-only --tags HEAD)
 UNAME_S := $(shell uname -s)
 XARGS:=xargs -r
 ifeq ($(UNAME_S),Darwin)
@@ -10,30 +7,27 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 COMMANDS_PATH:=github.com/MichaelMure/git-bug/commands
-LDFLAGS:=-X ${COMMANDS_PATH}.GitCommit=${GIT_COMMIT} \
-	-X ${COMMANDS_PATH}.GitLastTag=${GIT_LAST_TAG} \
-	-X ${COMMANDS_PATH}.GitExactTag=${GIT_EXACT_TAG}
 
 .PHONY: build
 build:
 	go generate
-	go build -ldflags "$(LDFLAGS)" .
+	go build .
 
 # produce a build debugger friendly
 .PHONY: debug-build
 debug-build:
 	go generate
-	go build -ldflags "$(LDFLAGS)" -gcflags=all="-N -l" .
+	go build -gcflags=all="-N -l" .
 
 .PHONY: install
 install:
 	go generate
-	go install -ldflags "$(LDFLAGS)" .
+	go install .
 
 .PHONY: releases
 releases:
 	go generate
-	go run github.com/mitchellh/gox@v1.0.1 -ldflags "$(LDFLAGS)" -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	go run github.com/mitchellh/gox@v1.0.1 -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 secure: secure-practices secure-vulnerabilities
 
@@ -62,7 +56,7 @@ pack-webui:
 # produce a build that will fetch the web UI from the filesystem instead of from the binary
 .PHONY: debug-webui
 debug-webui:
-	go build -ldflags "$(LDFLAGS)" -tags=debugwebui
+	go build -tags=debugwebui
 
 .PHONY: clean-local-bugs
 clean-local-bugs:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 GIT_COMMIT:=$(shell git rev-list -1 HEAD)
-GIT_LAST_TAG:=$(shell git describe --dirty --tags)
+GIT_LAST_TAG:=$(shell git describe --abbrev=0 --tags)
 GIT_EXACT_TAG:=$(shell git name-rev --name-only --tags HEAD)
 UNAME_S := $(shell uname -s)
 XARGS:=xargs -r

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-GIT_COMMIT:=$(shell git rev-parse --short HEAD)
+GIT_COMMIT:=$(shell git rev-list -1 HEAD)
 GIT_LAST_TAG:=$(shell git describe --dirty --tags)
 GIT_EXACT_TAG:=$(shell git name-rev --name-only --tags HEAD)
 UNAME_S := $(shell uname -s)

--- a/commands/root.go
+++ b/commands/root.go
@@ -53,7 +53,7 @@ the same git remote you are already using to collaborate with other people.
 					if commit, dirty, err := getCommitAndDirty(); err == nil {
 						root.Version = fmt.Sprintf("dev-%.10s", commit)
 
-						if dirty != "" {
+						if dirty {
 							root.Version = fmt.Sprintf("%s-dirty", root.Version)
 						}
 					} else {
@@ -112,13 +112,14 @@ func Execute() {
 	}
 }
 
-func getCommitAndDirty() (commit, dirty string, err error) {
-	var d, c string
+func getCommitAndDirty() (commit string, dirty bool, err error) {
+	var c string
+	var d bool
 
 	info, ok := debug.ReadBuildInfo()
 
 	if !ok {
-		return d, c, errors.New("unable to read build info")
+		return c, d, errors.New("unable to read build info")
 	}
 
 	// get the commit and modified status
@@ -129,7 +130,7 @@ func getCommitAndDirty() (commit, dirty string, err error) {
 			c = kv.Value
 		case "vcs.modified":
 			if kv.Value == "true" {
-				d = "dirty"
+				d = true
 			}
 		}
 	}

--- a/doc/man/git-bug-bridge-new.1
+++ b/doc/man/git-bug-bridge-new.1
@@ -13,13 +13,7 @@ git-bug-bridge-new - Configure a new bridge
 
 .SH DESCRIPTION
 .PP
-.RS
-
-.nf
 Configure a new bridge by passing flags or/and using interactive terminal prompts. You can avoid all the terminal prompts by passing all the necessary flags to configure your bridge.
-
-.fi
-.RE
 
 
 .SH OPTIONS

--- a/doc/md/git-bug_bridge_new.md
+++ b/doc/md/git-bug_bridge_new.md
@@ -4,7 +4,7 @@ Configure a new bridge
 
 ### Synopsis
 
-	Configure a new bridge by passing flags or/and using interactive terminal prompts. You can avoid all the terminal prompts by passing all the necessary flags to configure your bridge.
+Configure a new bridge by passing flags or/and using interactive terminal prompts. You can avoid all the terminal prompts by passing all the necessary flags to configure your bridge.
 
 ```
 git-bug bridge new [flags]


### PR DESCRIPTION
Resolves #928 

In Go 1.18+ `debug.ReadBuildInfo` contains revision so we can read it from there when we are installing git-bug with `go install`.

In this PR we are utilizing the following attributes of `debug.BuildInfo`:
- `vcs.revision` - get commit hash
- `vcs.modified` - identifies whether the state of project is clean
- `vcs.time` - in discussion

This change introduces new version schema:

- `v0.8.0` - release
- `v0.8.0-dev-xyxyxy` - non release, at commit `xyxyxy`
- `v0.8.0-dev-xyxyxy-dirty` - same as above, but also dirty
- `dev-xyxyxy` - we don't know the tag, at commit `xyxyxy`
- `dev-xyxyxy-dirty` - same but also dirty
