### PR TITLE
commands: different pattern to detect changed flags

### DIFF
--- a/commands/bug/bug_test.go
+++ b/commands/bug/bug_test.go
@@ -72,9 +72,10 @@ $`
 			env, _ := testenv.NewTestEnvAndBug(t)
 
 			opts := bugOptions{
-				sortDirection: "asc",
-				sortBy:        "creation",
-				outputFormat:  testcase.format,
+				sortDirection:       "asc",
+				sortBy:              "creation",
+				outputFormat:        testcase.format,
+				outputFormatChanged: true, // disable auto-detect
 			}
 
 			require.NoError(t, runBug(env, opts, []string{}))

--- a/doc/man/git-bug-bug.1
+++ b/doc/man/git-bug-bug.1
@@ -61,7 +61,7 @@ You can pass an additional query to filter and order the list. This query can be
 	Select the sorting direction. Valid values are [asc,desc]
 
 .PP
-\fB-f\fP, \fB--format\fP=""
+\fB-f\fP, \fB--format\fP="default"
 	Select the output formatting style. Valid values are [default,plain,id,json,org-mode]
 
 .PP

--- a/doc/md/git-bug_bug.md
+++ b/doc/md/git-bug_bug.md
@@ -42,7 +42,7 @@ git bug status:open --by creation "foo bar" baz
   -n, --no strings            Filter by absence of something. Valid values are [label]
   -b, --by string             Sort the results by a characteristic. Valid values are [id,creation,edit] (default "creation")
   -d, --direction string      Select the sorting direction. Valid values are [asc,desc] (default "asc")
-  -f, --format string         Select the output formatting style. Valid values are [default,plain,id,json,org-mode]
+  -f, --format string         Select the output formatting style. Valid values are [default,plain,id,json,org-mode] (default "default")
   -h, --help                  help for bug
 ```
 


### PR DESCRIPTION
I'm not fully sure if that's the right way. The important difference is that it doesn't impact the doc, keeping "default" here as the default value instead of removing entirely.