### PR TITLE
fix(#971): parse submodule .git files instead of erroring

### DIFF
--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -172,25 +172,24 @@ func detectGitPath(path string) (string, error) {
 		if err == nil {
 			if !fi.IsDir() {
 				// See if our .git item is a dotfile that holds a submodule reference
-				dotfile, err := os.Open(fi.Name())
+				dotfile, err := os.Open(filepath.Join(path, fi.Name()))
 				if err != nil {
-					// Can't open" error
+					// Can't open error
 					return "", fmt.Errorf(".git exists but is not a directory or a readable file: %w", err)
 				}
 				// We aren't going to defer the dotfile.Close, because we might keep looping, so we have to be sure to
 				// clean up before returning an error
 				reader := bufio.NewReader(dotfile)
 				line, _, err := reader.ReadLine()
+				_ = dotfile.Close()
 				if err != nil {
-					_ = dotfile.Close()
 					return "", fmt.Errorf(".git exists but is not a direcctory and cannot be read: %w", err)
 				}
 				dotContent := string(line)
 				if strings.HasPrefix(dotContent, "gitdir:") {
-					_ = dotfile.Close()
 					// This is a submodule parent path link. Strip the prefix, clean the string of whitespace just to
 					// be safe, and return
-					dotContent = strings.TrimSpace(dotContent[7:])
+					dotContent = strings.TrimSpace(strings.TrimPrefix(dotContent, "gitdir: "))
 					return dotContent, nil
 				}
 				return "", fmt.Errorf(".git exist but is not a directory")

--- a/repository/gogit.go
+++ b/repository/gogit.go
@@ -192,7 +192,7 @@ func detectGitPath(path string) (string, error) {
 					dotContent = strings.TrimSpace(strings.TrimPrefix(dotContent, "gitdir: "))
 					return dotContent, nil
 				}
-				return "", fmt.Errorf(".git exist but is not a directory")
+				return "", fmt.Errorf(".git exist but is not a directory or module/workspace file")
 			}
 			return filepath.Join(path, ".git"), nil
 		}

--- a/repository/gogit_test.go
+++ b/repository/gogit_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -80,4 +81,22 @@ func TestGoGitRepo_Indexes(t *testing.T) {
 	indexA, err = repo.GetIndex("a")
 	require.NoError(t, err)
 	require.NotZero(t, indexA)
+}
+
+func TestGoGit_DetectsSubmodules(t *testing.T) {
+	expectedPath := "../foo/bar"
+	submoduleData := "gitdir: " + expectedPath
+	d := t.TempDir()
+	if f, err := os.Create(filepath.Join(d, ".git")); err != nil {
+		t.Fatal("could not create necessary temp file:", err)
+	} else {
+		t.Log(f.Name())
+		if _, err := f.Write([]byte(submoduleData)); err != nil {
+			t.Fatal("could not write necessary data to temp file:", err)
+		}
+		_ = f.Close()
+	}
+	result, err := detectGitPath(d)
+	assert.Empty(t, err)
+	assert.Equal(t, expectedPath, result)
 }

--- a/repository/gogit_test.go
+++ b/repository/gogit_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,19 +85,14 @@ func TestGoGitRepo_Indexes(t *testing.T) {
 }
 
 func TestGoGit_DetectsSubmodules(t *testing.T) {
-	expectedPath := "../foo/bar"
-	submoduleData := "gitdir: " + expectedPath
+	repo := CreateGoGitTestRepo(t, false)
+	expected := filepath.Join(goGitRepoDir(t, repo), "/.git")
+
 	d := t.TempDir()
-	if f, err := os.Create(filepath.Join(d, ".git")); err != nil {
-		t.Fatal("could not create necessary temp file:", err)
-	} else {
-		t.Log(f.Name())
-		if _, err := f.Write([]byte(submoduleData)); err != nil {
-			t.Fatal("could not write necessary data to temp file:", err)
-		}
-		_ = f.Close()
-	}
-	result, err := detectGitPath(d)
+	err := os.WriteFile(filepath.Join(d, ".git"), []byte(fmt.Sprintf("gitdir: %s", expected)), 0600)
+	require.NoError(t, err)
+
+	result, err := detectGitPath(d, 0)
 	assert.Empty(t, err)
-	assert.Equal(t, expectedPath, result)
+	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
Altered logic for detecting git directory. Instead of erroring on non-direcctory .git files, now parses the file and returns the linked gitdir.

Note that since the module is a different repository, you have to `git bug user new` in the submodule before using git-bug. I've never used working trees, so I haven't tested that.

Also, I'm brand new to this project and haven't quite worked out how to add a unit test for this. Happy to do that if needed before this PR can be accepted.