### PR TITLE
Use HTTPS repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Or from the ports collection
 <details><summary>Compile from git (unstable)</summary>
 
 ```shell
-git clone git@github.com:MichaelMure/git-bug.git
+git clone https://github.com/MichaelMure/git-bug.git
 make install
 ```
 


### PR DESCRIPTION
When cloning this repo for installation (as opposed to development), users should use the HTTPS url for this repo, as they almost certainly do not have the necessary access rights to clone via SSH.