### PR TITLE
fix: run the presubmit pipeline for PRs

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,15 +1,16 @@
 # //.github/workflows:presubmit.yml
 #
 # This file exists to define the steps executed for a push to each tree matching
-# the pattern `refs/heads/*`, excluding the default ref. For configuring the
+# the pattern `refs/heads/*`, excluding the default ref, when they are used as
+# the head for a pull request against the default tree. For configuring the
 # steps that occur after a push to the trunk branch, see
 # `//.github/workflows:trunk.yml`.
 ---
 name: presubmit
 
 on:
-  push:
-    branches-ignore:
+  pull_request:
+    branches:
       - master
 
 concurrency:


### PR DESCRIPTION
```
fix: run the presubmit pipeline for PRs

commit 5eabe549e4f7fc98bbdf4e7b285cec00e5da4e99 refactored the workflows
so that they were orchestrated with reusable workflows. an unintended
side-effect of the rules that were created prevents the presubmit
pipeline from executing for pull requests made against this repository.

this change refactors this, so that the presubmit pipeline will _only_
run for pull requests against the default tree of this repository. we
explicitly remove the `on: push` event for it, in order to avoid overlap
that will occur for commits made in this repository that are also part
of a PR.

Change-Id: I56abc35c98cc40a06066952f2b6ed9194b1ab903
```

