### PR TITLE
feat: improved lifecycle management with stale-bot

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,31 +1,10 @@
 name: cron
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' # every day at 00:00
+    - cron: '17 3 * * *' # every day at 03:17 UTC
 
 jobs:
-  stale:
-    name: stale/issue-and-pr
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/stale@v9
-        with:
-          stale-issue-label: lifecycle/stale
-          stale-pr-label: lifecycle/stale
-          days-before-stale: 90
-          days-before-close: 30
-          stale-issue-message: |
-            This bot triages untriaged issues and PRs according to the following rules:
-
-            - After 90 days of inactivity, the `lifecycle/stale` label is applied
-            - After 30 days of inactivity since `lifecycle/stale` was applied, the issue is closed
-
-            To remove the stale status, you can:
-
-            - Remove the `lifecycle/stale` label
-            - Comment on this issue
+  lifecycle:
+    if: github.event.schedule == '17 3 * * *'
+    uses: ./.github/workflows/stale-bot.yml

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -1,0 +1,95 @@
+name: lifecycle
+
+on:
+  workflow_call:
+    inputs:
+      issue-message:
+        type: string
+        default: |
+          This bot triages issues in order to help the maintainers identify what
+          needs attention, according to the following lifecycle rules:
+
+          - After 90 days of inactivity, `lifecycle/stale` is applied
+          - After 90 days of inactivity since `lifecycle/stale` was applied,
+            `lifecycle/rotten` is applied
+
+          **This bot will not automatically close stale issues.**
+
+          To remove the stale status, you can:
+
+          - Remove the stale label from this issue
+          - Comment on this issue
+          - Close this issue
+          - Offer to help out with triaging
+
+          ---
+
+          To avoid automatic lifecycle management of this issue, add
+          `lifecycle/frozen`.
+
+      pr-message:
+        type: string
+        default: |
+          This bot triages pull requests in order to help the maintainers
+          identify what needs attention, according to the following lifecycle
+          rules:
+
+          - After 90 days of inactivity, `lifecycle/stale` is applied
+          - After 90 days of inactivity since `lifecycle/stale` was applied,
+            `lifecycle/rotten` is applied
+
+          **This bot will not automatically close stale pull requests.**
+
+          To remove the stale status, you can:
+
+          - Remove the stale label from this pull request
+          - Comment on this issue
+          - Close this issue
+          - Offer to help out with triage and code review
+
+          ---
+
+          To avoid automatic lifecycle management of this pull request, add
+          `lifecycle/frozen`.
+
+jobs:
+  stale:
+    name: stale
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-close: -1
+          days-before-stale: 90
+          exempt-all-milestones: true
+          exempt-issue-labels: lifecycle/frozen,lifecycle/rotten,lifecycle/stale
+          exempt-pr-labels: lifecycle/frozen,lifecycle/rotten,lifecycle/stale
+          labels-to-remove-when-stale: lifecycle/active
+          stale-issue-label: lifecycle/stale
+          stale-issue-message: ${{ inputs.issue-message }}
+          stale-pr-label: lifecycle/stale
+          stale-pr-message: ${{ inputs.pr-message }}
+
+  rotten:
+    name: rotten
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-close: -1
+          days-before-stale: 180
+          exempt-all-milestones: true
+          labels-to-remove-when-stale: lifecycle/active,lifecycle/stale
+          exempt-issue-labels: lifecycle/frozen
+          exempt-pr-labels: lifecycle/frozen
+          only-labels: lifecycle/stale
+          stale-issue-label: lifecycle/rotten
+          stale-issue-message: ${{ inputs.issue-message }}
+          stale-pr-label: lifecycle/rotten
+          stale-pr-message: ${{ inputs.pr-message }}


### PR DESCRIPTION
```
feat: improved lifecycle management with stale-bot

This change refactors the automatic lifecycle management workflow that
uses the `stale-bot` action library, such that neither issues nor pull
requests will be closed.

An additional label of `lifecycle/rotten` has been added to indicate
issues or pull requests which have been inactive for 180 days or more.

Change-Id: Ia748552c91ada43b4a762879db469132131956f0
```

