### PR TITLE
fix: set GitLastTag to an empty string when git-describe errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 GIT_COMMIT:=$(shell git rev-list -1 HEAD)
-GIT_LAST_TAG:=$(shell git describe --abbrev=0 --tags)
+GIT_LAST_TAG:=$(shell git describe --abbrev=0 --tags 2>/dev/null || true)
 GIT_EXACT_TAG:=$(shell git name-rev --name-only --tags HEAD)
 UNAME_S := $(shell uname -s)
 XARGS:=xargs -r
@@ -10,9 +10,9 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 COMMANDS_PATH:=github.com/git-bug/git-bug/commands
-LDFLAGS:=-X ${COMMANDS_PATH}.GitCommit=${GIT_COMMIT} \
-	-X ${COMMANDS_PATH}.GitLastTag=${GIT_LAST_TAG} \
-	-X ${COMMANDS_PATH}.GitExactTag=${GIT_EXACT_TAG}
+LDFLAGS:=-X ${COMMANDS_PATH}.GitCommit="${GIT_COMMIT}" \
+	-X ${COMMANDS_PATH}.GitLastTag="${GIT_LAST_TAG}" \
+	-X ${COMMANDS_PATH}.GitExactTag="${GIT_EXACT_TAG}"
 
 .PHONY: build
 build:


### PR DESCRIPTION
This change refactors the call to `git-describe` made in `//:Makefile`,
such that if the call made to populate the `GitLastTag` build argument
fails for any reason, the value is an empty string.

This resolves a fairly common situation in CI, and reproducible
elsewhere, if the local repository does not have any tags.

Change-Id: Ie8e06360d5a4016596b96c6371ce4e32ad6a8afb