### PR TITLE
fix: checkout repo before setting up go environment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,13 +11,13 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Build
         run: make

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -29,11 +29,11 @@ jobs:
       contents: write
       deployments: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.2
-
-      - uses: actions/checkout@v4
 
       - name: Run benchmark
         run: go test -v ./... -bench=. -run=xxx -benchmem | tee output.txt


### PR DESCRIPTION
This change ensures that the `go.sum` file used by the
`actions/setup-go` action as the cache identifier exists in the working
tree.

Closes: #1382
Change-Id: I0318bfa6e7d7859baf6600ff71715eaef92b401b