### PR TITLE
feat: use git-describe for setting the version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 SYSTEM=$(shell nix eval --impure --expr 'builtins.currentSystem' --raw 2>/dev/null || echo '')
 
-TAG:=$(shell git describe --match 'v*' --always HEAD)
+TAG:=$(shell git describe --match 'v*' --always --dirty --broken)
 LDFLAGS:=-X main.version="${TAG}"
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 SYSTEM=$(shell nix eval --impure --expr 'builtins.currentSystem' --raw 2>/dev/null || echo '')
 
-TAG:=$(shell git name-rev --name-only --tags HEAD)
+TAG:=$(shell git describe --match 'v*' --always HEAD)
 LDFLAGS:=-X main.version="${TAG}"
 
 all: build


### PR DESCRIPTION
This change uses git-describe to set the version string, which improves the user experience by always showing the most recent tag, with additional git data (such as the delta of a commits between that tag and HEAD). 

Before this change, we see the following output:

    git-bug undefined 7468b3793fbf go1.24.9 linux amd64

With this change, the output becomes:

    git-bug v0.10.1-24-gb957ba2e-dirty b957ba2e5947/dirty go1.24.9 linux amd64

The duplicated VCS information does add noise, however, this will be dealt with in a future commit.