### PR TITLE
feat(identity): store and retrieve full GPG keys

### DIFF
--- a/entities/identity/identity_test.go
+++ b/entities/identity/identity_test.go
@@ -13,65 +13,65 @@ import (
 	"github.com/git-bug/git-bug/util/timestamp"
 )
 
-type testIdentityMock struct {
+type mockIdentity struct {
 	name  string
 	login string
 	email string
 }
 
-func (m *testIdentityMock) Name() string {
+func (m *mockIdentity) Name() string {
 	return m.name
 }
 
-func (m *testIdentityMock) Login() string {
+func (m *mockIdentity) Login() string {
 	return m.login
 }
 
-func (m *testIdentityMock) Email() string {
+func (m *mockIdentity) Email() string {
 	return m.email
 }
 
-func (m *testIdentityMock) DisplayName() string {
+func (m *mockIdentity) DisplayName() string {
 	return m.name
 }
 
-func (m *testIdentityMock) AvatarUrl() string {
+func (m *mockIdentity) AvatarUrl() string {
 	return ""
 }
 
-func (m *testIdentityMock) Keys() []*Key {
+func (m *mockIdentity) Keys() []*Key {
 	return nil
 }
 
-func (m *testIdentityMock) SigningKey(repo repository.RepoKeyring) (*Key, error) {
+func (m *mockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) {
 	return nil, nil
 }
 
-func (m *testIdentityMock) ValidKeysAtTime(clockName string, time lamport.Time) []*Key {
+func (m *mockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key {
 	return nil
 }
 
-func (m *testIdentityMock) LastModification() timestamp.Timestamp {
+func (m *mockIdentity) LastModification() timestamp.Timestamp {
 	return 0
 }
 
-func (m *testIdentityMock) LastModificationLamports() map[string]lamport.Time {
+func (m *mockIdentity) LastModificationLamports() map[string]lamport.Time {
 	return nil
 }
 
-func (m *testIdentityMock) IsProtected() bool {
+func (m *mockIdentity) IsProtected() bool {
 	return false
 }
 
-func (m *testIdentityMock) Validate() error {
+func (m *mockIdentity) Validate() error {
 	return nil
 }
 
-func (m *testIdentityMock) NeedCommit() bool {
+func (m *mockIdentity) NeedCommit() bool {
 	return false
 }
 
-func (m *testIdentityMock) Id() entity.Id {
+func (m *mockIdentity) Id() entity.Id {
 	return ""
 }
 
@@ -202,7 +202,7 @@ func TestIdentityCommitLoad(t *testing.T) {
 	require.True(t, identitiesEqual(identity, loaded), "loaded identity should equal original (comparing by key fingerprint)")
 
 	// multiple versions
-	testIdentity := &testIdentityMock{name: "René Descartes", email: "rene.descartes@example.com"}
+	testIdentity := &mockIdentity{name: "René Descartes", email: "rene.descartes@example.com"}
 	identity, err = NewIdentityFull(repo, "René Descartes", "rene.descartes@example.com", "", "", []*Key{generatePublicKey(testIdentity)})
 	require.NoError(t, err)
 
@@ -290,7 +290,7 @@ func commitsAreSet(t *testing.T, identity *Identity) {
 
 // Test that the correct crypto keys are returned for a given lamport time
 func TestIdentity_ValidKeysAtTime(t *testing.T) {
-	testIdentity := &testIdentityMock{name: "Test User", email: "test@example.com"}
+	testIdentity := &mockIdentity{name: "Test User", email: "test@example.com"}
 	pubKeyA := generatePublicKey(testIdentity)
 	pubKeyB := generatePublicKey(testIdentity)
 	pubKeyC := generatePublicKey(testIdentity)

--- a/entities/identity/identity_test.go
+++ b/entities/identity/identity_test.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -9,7 +10,131 @@ import (
 	"github.com/git-bug/git-bug/entity"
 	"github.com/git-bug/git-bug/repository"
 	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
+
+type testIdentityMock struct {
+	name  string
+	login string
+	email string
+}
+
+func (m *testIdentityMock) Name() string                                        { return m.name }
+func (m *testIdentityMock) Login() string                                      { return m.login }
+func (m *testIdentityMock) Email() string                                     { return m.email }
+func (m *testIdentityMock) DisplayName() string                               { return m.name }
+func (m *testIdentityMock) AvatarUrl() string                                 { return "" }
+func (m *testIdentityMock) Keys() []*Key                                      { return nil }
+func (m *testIdentityMock) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
+func (m *testIdentityMock) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
+func (m *testIdentityMock) LastModification() timestamp.Timestamp             { return 0 }
+func (m *testIdentityMock) LastModificationLamports() map[string]lamport.Time { return nil }
+func (m *testIdentityMock) IsProtected() bool                                 { return false }
+func (m *testIdentityMock) Validate() error                                   { return nil }
+func (m *testIdentityMock) NeedCommit() bool                                  { return false }
+func (m *testIdentityMock) Id() entity.Id                                     { return "" }
+
+// identitiesEqual compares two identities by their versions
+func identitiesEqual(left, right *Identity) bool {
+	if left == nil && right == nil {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+
+	if len(left.versions) != len(right.versions) {
+		return false
+	}
+
+	for i, lv := range left.versions {
+		rv := right.versions[i]
+		if !versionsEqual(lv, rv) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// versionsEqual compares two versions, comparing keys by their public key fingerprints
+func versionsEqual(left, right *version) bool {
+	if left == nil && right == nil {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+
+	// Compare basic fields
+	if left.name != right.name || left.email != right.email ||
+		left.login != right.login || left.avatarURL != right.avatarURL ||
+		left.unixTime != right.unixTime {
+		return false
+	}
+
+	// Compare times
+	if len(left.times) != len(right.times) {
+		return false
+	}
+	for k, tv := range left.times {
+		ov, ok := right.times[k]
+		if !ok || tv != ov {
+			return false
+		}
+	}
+
+	// Compare keys by fingerprint
+	if len(left.keys) != len(right.keys) {
+		return false
+	}
+	for i, k := range left.keys {
+		if !keysEqual(k, right.keys[i]) {
+			return false
+		}
+	}
+
+	// Compare nonce
+	if len(left.nonce) != len(right.nonce) {
+		return false
+	}
+	for i, n := range left.nonce {
+		if n != right.nonce[i] {
+			return false
+		}
+	}
+
+	// Compare metadata
+	if len(left.metadata) != len(right.metadata) {
+		return false
+	}
+	for k, vm := range left.metadata {
+		om, ok := right.metadata[k]
+		if !ok || vm != om {
+			return false
+		}
+	}
+
+	// Don't compare id and commitHash as they're derived fields
+	return true
+}
+
+// keysEqual compares two keys by their public key fingerprint
+func keysEqual(left, right *Key) bool {
+	if left == nil && right == nil {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+	if left.public == nil && right.public == nil {
+		return true
+	}
+	if left.public == nil || right.public == nil {
+		return false
+	}
+	return bytes.Equal(left.public.Fingerprint[:], right.public.Fingerprint[:])
+}
 
 // Test the commit and load of an Identity with multiple versions
 func TestIdentityCommitLoad(t *testing.T) {
@@ -33,22 +158,22 @@ func TestIdentityCommitLoad(t *testing.T) {
 	loaded, err := ReadLocal(repo, identity.Id())
 	require.NoError(t, err)
 	commitsAreSet(t, loaded)
-	require.Equal(t, identity, loaded)
+	require.True(t, identitiesEqual(identity, loaded), "loaded identity should equal original (comparing by key fingerprint)")
 
 	// multiple versions
-
-	identity, err = NewIdentityFull(repo, "René Descartes", "rene.descartes@example.com", "", "", []*Key{generatePublicKey()})
+	testIdentity := &testIdentityMock{name: "René Descartes", email: "rene.descartes@example.com"}
+	identity, err = NewIdentityFull(repo, "René Descartes", "rene.descartes@example.com", "", "", []*Key{generatePublicKey(testIdentity)})
 	require.NoError(t, err)
 
 	idBeforeCommit = identity.Id()
 
 	err = identity.Mutate(repo, func(orig *Mutator) {
-		orig.Keys = []*Key{generatePublicKey()}
+		orig.Keys = []*Key{generatePublicKey(testIdentity)}
 	})
 	require.NoError(t, err)
 
 	err = identity.Mutate(repo, func(orig *Mutator) {
-		orig.Keys = []*Key{generatePublicKey()}
+		orig.Keys = []*Key{generatePublicKey(testIdentity)}
 	})
 	require.NoError(t, err)
 
@@ -65,19 +190,19 @@ func TestIdentityCommitLoad(t *testing.T) {
 	loaded, err = ReadLocal(repo, identity.Id())
 	require.NoError(t, err)
 	commitsAreSet(t, loaded)
-	require.Equal(t, identity, loaded)
+	require.True(t, identitiesEqual(identity, loaded), "loaded identity should equal original (comparing by key fingerprint)")
 
 	// add more version
 
 	err = identity.Mutate(repo, func(orig *Mutator) {
 		orig.Email = "rene@descartes.com"
-		orig.Keys = []*Key{generatePublicKey()}
+		orig.Keys = []*Key{generatePublicKey(testIdentity)}
 	})
 	require.NoError(t, err)
 
 	err = identity.Mutate(repo, func(orig *Mutator) {
 		orig.Email = "rene@descartes.com"
-		orig.Keys = []*Key{generatePublicKey(), generatePublicKey()}
+		orig.Keys = []*Key{generatePublicKey(testIdentity), generatePublicKey(testIdentity)}
 	})
 	require.NoError(t, err)
 
@@ -92,7 +217,7 @@ func TestIdentityCommitLoad(t *testing.T) {
 	loaded, err = ReadLocal(repo, identity.Id())
 	require.NoError(t, err)
 	commitsAreSet(t, loaded)
-	require.Equal(t, identity, loaded)
+	require.True(t, identitiesEqual(identity, loaded), "loaded identity should equal original (comparing by key fingerprint)")
 }
 
 func TestIdentityMutate(t *testing.T) {
@@ -124,11 +249,12 @@ func commitsAreSet(t *testing.T, identity *Identity) {
 
 // Test that the correct crypto keys are returned for a given lamport time
 func TestIdentity_ValidKeysAtTime(t *testing.T) {
-	pubKeyA := generatePublicKey()
-	pubKeyB := generatePublicKey()
-	pubKeyC := generatePublicKey()
-	pubKeyD := generatePublicKey()
-	pubKeyE := generatePublicKey()
+	testIdentity := &testIdentityMock{name: "Test User", email: "test@example.com"}
+	pubKeyA := generatePublicKey(testIdentity)
+	pubKeyB := generatePublicKey(testIdentity)
+	pubKeyC := generatePublicKey(testIdentity)
+	pubKeyD := generatePublicKey(testIdentity)
+	pubKeyE := generatePublicKey(testIdentity)
 
 	identity := Identity{
 		versions: []*version{

--- a/entities/identity/identity_test.go
+++ b/entities/identity/identity_test.go
@@ -19,20 +19,61 @@ type testIdentityMock struct {
 	email string
 }
 
-func (m *testIdentityMock) Name() string                                        { return m.name }
-func (m *testIdentityMock) Login() string                                      { return m.login }
-func (m *testIdentityMock) Email() string                                     { return m.email }
-func (m *testIdentityMock) DisplayName() string                               { return m.name }
-func (m *testIdentityMock) AvatarUrl() string                                 { return "" }
-func (m *testIdentityMock) Keys() []*Key                                      { return nil }
-func (m *testIdentityMock) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
-func (m *testIdentityMock) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
-func (m *testIdentityMock) LastModification() timestamp.Timestamp             { return 0 }
-func (m *testIdentityMock) LastModificationLamports() map[string]lamport.Time { return nil }
-func (m *testIdentityMock) IsProtected() bool                                 { return false }
-func (m *testIdentityMock) Validate() error                                   { return nil }
-func (m *testIdentityMock) NeedCommit() bool                                  { return false }
-func (m *testIdentityMock) Id() entity.Id                                     { return "" }
+func (m *testIdentityMock) Name() string {
+	return m.name
+}
+
+func (m *testIdentityMock) Login() string {
+	return m.login
+}
+
+func (m *testIdentityMock) Email() string {
+	return m.email
+}
+
+func (m *testIdentityMock) DisplayName() string {
+	return m.name
+}
+
+func (m *testIdentityMock) AvatarUrl() string {
+	return ""
+}
+
+func (m *testIdentityMock) Keys() []*Key {
+	return nil
+}
+
+func (m *testIdentityMock) SigningKey(repo repository.RepoKeyring) (*Key, error) {
+	return nil, nil
+}
+
+func (m *testIdentityMock) ValidKeysAtTime(clockName string, time lamport.Time) []*Key {
+	return nil
+}
+
+func (m *testIdentityMock) LastModification() timestamp.Timestamp {
+	return 0
+}
+
+func (m *testIdentityMock) LastModificationLamports() map[string]lamport.Time {
+	return nil
+}
+
+func (m *testIdentityMock) IsProtected() bool {
+	return false
+}
+
+func (m *testIdentityMock) Validate() error {
+	return nil
+}
+
+func (m *testIdentityMock) NeedCommit() bool {
+	return false
+}
+
+func (m *testIdentityMock) Id() entity.Id {
+	return ""
+}
 
 // identitiesEqual compares two identities by their versions
 func identitiesEqual(left, right *Identity) bool {

--- a/entities/identity/key.go
+++ b/entities/identity/key.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -19,43 +18,68 @@ import (
 var errNoPrivateKey = fmt.Errorf("no private key")
 
 type Key struct {
-	public  *packet.PublicKey
-	private *packet.PrivateKey
+	public *packet.PublicKey
+	entity *openpgp.Entity
 }
 
-// GenerateKey generate a key pair (public+private)
+type keyConfig struct {
+	time time.Time
+}
+
+type KeyOption func(*keyConfig)
+
+// WithTime sets a specific time for key generation.
+// Useful for testing to ensure consistent, deterministic keys.
+func WithTime(t time.Time) KeyOption {
+	return func(cfg *keyConfig) {
+		cfg.time = t
+	}
+}
+
+// GenerateKey generate a key pair (public+private) with identity metadata.
 // The type and configuration of the key is determined by the default value in go's OpenPGP.
-func GenerateKey() *Key {
-	entity, err := openpgp.NewEntity("", "", "", &packet.Config{
-		// The armored format doesn't include the creation time, which makes the round-trip data not being fully equal.
-		// We don't care about the creation time so we can set it to the zero value.
+func GenerateKey(id Interface, opts ...KeyOption) *Key {
+	cfg := &keyConfig{
+		time: time.Now(),
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	entity, err := openpgp.NewEntity(id.Name(), id.Login(), id.Email(), &packet.Config{
 		Time: func() time.Time {
-			return time.Time{}
+			return cfg.time
 		},
 	})
 	if err != nil {
 		panic(err)
 	}
+
 	return &Key{
-		public:  entity.PrimaryKey,
-		private: entity.PrivateKey,
+		public: entity.PrimaryKey,
+		entity: entity,
 	}
 }
 
 // generatePublicKey generate only a public key (only useful for testing)
 // See GenerateKey for the details.
-func generatePublicKey() *Key {
-	k := GenerateKey()
-	k.private = nil
+func generatePublicKey(id Interface) *Key {
+	k := GenerateKey(id, WithTime(time.Time{}))
+	// k.entity = nil
+	k.entity.PrivateKey = nil
 	return k
 }
 
 func (k *Key) Public() *packet.PublicKey {
-	return k.public
+	return k.entity.PrimaryKey
+}
+
+func (k *Key) Version() string {
+	return "new"
 }
 
 func (k *Key) Private() *packet.PrivateKey {
-	return k.private
+	return k.entity.PrivateKey
 }
 
 func (k *Key) Validate() error {
@@ -66,8 +90,8 @@ func (k *Key) Validate() error {
 		return fmt.Errorf("public key can't sign")
 	}
 
-	if k.private != nil {
-		if !k.private.CanSign() {
+	if k.entity != nil && k.entity.PrivateKey != nil {
+		if !k.entity.PrivateKey.CanSign() {
 			return fmt.Errorf("private key can't sign")
 		}
 	}
@@ -81,9 +105,9 @@ func (k *Key) Clone() *Key {
 	pub := *k.public
 	clone.public = &pub
 
-	if k.private != nil {
-		priv := *k.private
-		clone.private = &priv
+	if k.entity != nil {
+		entity := *k.entity
+		clone.entity = &entity
 	}
 
 	return clone
@@ -97,7 +121,7 @@ func (k *Key) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	err = k.public.Serialize(w)
+	err = k.entity.Serialize(w)
 	if err != nil {
 		return nil, err
 	}
@@ -109,40 +133,30 @@ func (k *Key) MarshalJSON() ([]byte, error) {
 }
 
 func (k *Key) UnmarshalJSON(data []byte) error {
-	// De-serialize only the public key, in the armored format.
+	// De-serialize the entity using the armored format.
 	var armored string
 	err := json.Unmarshal(data, &armored)
 	if err != nil {
 		return err
 	}
 
-	block, err := armor.Decode(strings.NewReader(armored))
-	if err == io.EOF {
-		return fmt.Errorf("no armored data found")
-	}
+	entities, err := openpgp.ReadArmoredKeyRing(strings.NewReader(armored))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to read armored key ring")
 	}
 
-	if block.Type != openpgp.PublicKeyType {
-		return fmt.Errorf("invalid key type")
+	if len(entities) != 1 {
+		return fmt.Errorf("exactly one entity should be present - got %d", len(entities))
 	}
 
-	p, err := packet.Read(block.Body)
-	if err != nil {
-		return errors.Wrap(err, "failed to read public key packet")
-	}
+	entity := entities[0]
 
-	public, ok := p.(*packet.PublicKey)
-	if !ok {
-		return errors.New("got no packet.publicKey")
-	}
+	// The armored format (RFC 4880) doesn't preserve key creation timestamps.
+	// We don't care about the creation time, so we reset it to the zero value to ensure consistency.
+	entity.PrimaryKey.CreationTime = time.Time{}
 
-	// The armored format doesn't include the creation time, which makes the round-trip data not being fully equal.
-	// We don't care about the creation time so we can set it to the zero value.
-	public.CreationTime = time.Time{}
-
-	k.public = public
+	k.public = entity.PrimaryKey
+	k.entity = entity
 	return nil
 }
 
@@ -155,40 +169,28 @@ func (k *Key) loadPrivate(repo repository.RepoKeyring) error {
 		return err
 	}
 
-	block, err := armor.Decode(bytes.NewReader(item.Data))
-	if err == io.EOF {
-		return fmt.Errorf("no armored data found")
-	}
+	entities, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(item.Data))
 	if err != nil {
 		return err
 	}
 
-	if block.Type != openpgp.PrivateKeyType {
-		return fmt.Errorf("invalid key type")
+	if len(entities) != 1 {
+		return fmt.Errorf("examtly one entity should be stored - got %d", len(entities))
 	}
 
-	p, err := packet.Read(block.Body)
-	if err != nil {
-		return errors.Wrap(err, "failed to read private key packet")
-	}
+	// The armored format (RFC 4880) doesn't preserve key creation timestamps.
+	// We don't care about the creation time, so we reset it to the zero value to ensure consistency.
+	entities[0].PrivateKey.CreationTime = time.Time{}
+	k.entity = entities[0]
+	k.public = entities[0].PrimaryKey
 
-	private, ok := p.(*packet.PrivateKey)
-	if !ok {
-		return errors.New("got no packet.privateKey")
-	}
-
-	// The armored format doesn't include the creation time, which makes the round-trip data not being fully equal.
-	// We don't care about the creation time so we can set it to the zero value.
-	private.CreationTime = time.Time{}
-
-	k.private = private
 	return nil
 }
 
 // ensurePrivateKey attempt to load the corresponding private key if it is not loaded already.
 // If no private key is found, returns errNoPrivateKey
 func (k *Key) ensurePrivateKey(repo repository.RepoKeyring) error {
-	if k.private != nil {
+	if k.entity != nil && k.entity.PrivateKey != nil {
 		return nil
 	}
 
@@ -201,7 +203,7 @@ func (k *Key) storePrivate(repo repository.RepoKeyring) error {
 	if err != nil {
 		return err
 	}
-	err = k.private.Serialize(w)
+	err = k.entity.SerializePrivate(w, nil)
 	if err != nil {
 		return err
 	}
@@ -211,21 +213,11 @@ func (k *Key) storePrivate(repo repository.RepoKeyring) error {
 	}
 
 	return repo.Keyring().Set(repository.Item{
-		Key:  k.public.KeyIdString(),
+		Key:  k.entity.PrimaryKey.KeyIdString(),
 		Data: buf.Bytes(),
 	})
 }
 
 func (k *Key) PGPEntity() *openpgp.Entity {
-	e := &openpgp.Entity{
-		PrimaryKey: k.public,
-		PrivateKey: k.private,
-		Identities: map[string]*openpgp.Identity{},
-	}
-	// somehow initialize the proper fields with identity, self-signature ...
-	err := e.AddUserId("name", "", "", nil)
-	if err != nil {
-		panic(err)
-	}
-	return e
+	return k.entity
 }

--- a/entities/identity/key_test.go
+++ b/entities/identity/key_test.go
@@ -4,14 +4,40 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/git-bug/git-bug/entity"
 	"github.com/git-bug/git-bug/repository"
+	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
 
+type mockIdentity struct {
+	name  string
+	login string
+	email string
+}
+
+func (m *mockIdentity) Name() string                                        { return m.name }
+func (m *mockIdentity) Login() string                                      { return m.login }
+func (m *mockIdentity) Email() string                                     { return m.email }
+func (m *mockIdentity) DisplayName() string                               { return m.name }
+func (m *mockIdentity) AvatarUrl() string                                 { return "" }
+func (m *mockIdentity) Keys() []*Key                                      { return nil }
+func (m *mockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
+func (m *mockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
+func (m *mockIdentity) LastModification() timestamp.Timestamp             { return 0 }
+func (m *mockIdentity) LastModificationLamports() map[string]lamport.Time { return nil }
+func (m *mockIdentity) IsProtected() bool                                 { return false }
+func (m *mockIdentity) Validate() error                                   { return nil }
+func (m *mockIdentity) NeedCommit() bool                                  { return false }
+func (m *mockIdentity) Id() entity.Id                                     { return "" }
+
 func TestPublicKeyJSON(t *testing.T) {
-	k := generatePublicKey()
+	id := &mockIdentity{name: "John Smith", email: "jsmith@example.com"}
+	k := generatePublicKey(id)
 
 	dataJSON, err := json.Marshal(k)
 	require.NoError(t, err)
@@ -20,14 +46,16 @@ func TestPublicKeyJSON(t *testing.T) {
 	err = json.Unmarshal(dataJSON, &read)
 	require.NoError(t, err)
 
-	require.Equal(t, k, &read)
+	// Compare public keys since entities may differ in internal structure after deserialization
+	require.Equal(t, k.public.Fingerprint[:], read.public.Fingerprint[:])
 }
 
 func TestStoreLoad(t *testing.T) {
 	repo := repository.NewMockRepoKeyring()
 
 	// public + private
-	k := GenerateKey()
+	id := &mockIdentity{name: "John Smith", email: "jsmith@example.com"}
+	k := GenerateKey(id, WithTime(time.Time{}))
 
 	// Store
 
@@ -48,11 +76,11 @@ func TestStoreLoad(t *testing.T) {
 
 	require.Equal(t, k.public, read.public)
 
-	require.IsType(t, (*rsa.PrivateKey)(nil), k.private.PrivateKey)
+	require.IsType(t, (*rsa.PrivateKey)(nil), k.entity.PrivateKey.PrivateKey)
 
 	// See https://github.com/golang/crypto/pull/175
-	rsaPriv := read.private.PrivateKey.(*rsa.PrivateKey)
+	rsaPriv := read.entity.PrivateKey.PrivateKey.(*rsa.PrivateKey)
 	rsaPriv.Primes[0], rsaPriv.Primes[1] = rsaPriv.Primes[1], rsaPriv.Primes[0]
 
-	require.True(t, k.private.PrivateKey.(*rsa.PrivateKey).Equal(read.private.PrivateKey))
+	require.True(t, k.entity.PrivateKey.PrivateKey.(*rsa.PrivateKey).Equal(read.entity.PrivateKey.PrivateKey))
 }

--- a/entities/identity/key_test.go
+++ b/entities/identity/key_test.go
@@ -8,32 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/git-bug/git-bug/entity"
 	"github.com/git-bug/git-bug/repository"
-	"github.com/git-bug/git-bug/util/lamport"
-	"github.com/git-bug/git-bug/util/timestamp"
 )
 
-type mockIdentity struct {
-	name  string
-	login string
-	email string
-}
 
-func (m *mockIdentity) Name() string                                        { return m.name }
-func (m *mockIdentity) Login() string                                      { return m.login }
-func (m *mockIdentity) Email() string                                     { return m.email }
-func (m *mockIdentity) DisplayName() string                               { return m.name }
-func (m *mockIdentity) AvatarUrl() string                                 { return "" }
-func (m *mockIdentity) Keys() []*Key                                      { return nil }
-func (m *mockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
-func (m *mockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
-func (m *mockIdentity) LastModification() timestamp.Timestamp             { return 0 }
-func (m *mockIdentity) LastModificationLamports() map[string]lamport.Time { return nil }
-func (m *mockIdentity) IsProtected() bool                                 { return false }
-func (m *mockIdentity) Validate() error                                   { return nil }
-func (m *mockIdentity) NeedCommit() bool                                  { return false }
-func (m *mockIdentity) Id() entity.Id                                     { return "" }
 
 func TestPublicKeyJSON(t *testing.T) {
 	id := &mockIdentity{name: "John Smith", email: "jsmith@example.com"}

--- a/entities/identity/key_test.go
+++ b/entities/identity/key_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/git-bug/git-bug/repository"
 )
 
-
-
 func TestPublicKeyJSON(t *testing.T) {
 	id := &mockIdentity{name: "John Smith", email: "jsmith@example.com"}
 	k := generatePublicKey(id)

--- a/entities/identity/version_test.go
+++ b/entities/identity/version_test.go
@@ -11,7 +11,29 @@ import (
 	"github.com/git-bug/git-bug/entity"
 	"github.com/git-bug/git-bug/repository"
 	"github.com/git-bug/git-bug/util/lamport"
+	"github.com/git-bug/git-bug/util/timestamp"
 )
+
+type testVersionMockIdentity struct {
+	name  string
+	login string
+	email string
+}
+
+func (m *testVersionMockIdentity) Name() string                                        { return m.name }
+func (m *testVersionMockIdentity) Login() string                                      { return m.login }
+func (m *testVersionMockIdentity) Email() string                                     { return m.email }
+func (m *testVersionMockIdentity) DisplayName() string                               { return m.name }
+func (m *testVersionMockIdentity) AvatarUrl() string                                 { return "" }
+func (m *testVersionMockIdentity) Keys() []*Key                                      { return nil }
+func (m *testVersionMockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
+func (m *testVersionMockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
+func (m *testVersionMockIdentity) LastModification() timestamp.Timestamp             { return 0 }
+func (m *testVersionMockIdentity) LastModificationLamports() map[string]lamport.Time { return nil }
+func (m *testVersionMockIdentity) IsProtected() bool                                 { return false }
+func (m *testVersionMockIdentity) Validate() error                                   { return nil }
+func (m *testVersionMockIdentity) NeedCommit() bool                                  { return false }
+func (m *testVersionMockIdentity) Id() entity.Id                                     { return "" }
 
 func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 	repo := repository.NewMockRepo()
@@ -32,9 +54,10 @@ func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 func TestVersionJSON(t *testing.T) {
 	repo := makeIdentityTestRepo(t)
 
+	testIdentity := &testVersionMockIdentity{name: "name", email: "email", login: "login"}
 	keys := []*Key{
-		generatePublicKey(),
-		generatePublicKey(),
+		generatePublicKey(testIdentity),
+		generatePublicKey(testIdentity),
 	}
 
 	before, err := newVersion(repo, "name", "email", "login", "avatarUrl", keys)
@@ -74,5 +97,18 @@ func TestVersionJSON(t *testing.T) {
 	// make sure we now have an Id
 	expected.Id()
 
-	assert.Equal(t, expected, &after)
+	// Compare versions without Key objects since entities may differ in internal structure after deserialization
+	assert.Equal(t, expected.name, after.name)
+	assert.Equal(t, expected.email, after.email)
+	assert.Equal(t, expected.login, after.login)
+	assert.Equal(t, expected.avatarURL, after.avatarURL)
+	assert.Equal(t, expected.unixTime, after.unixTime)
+	assert.Equal(t, expected.times, after.times)
+	assert.Equal(t, expected.metadata, after.metadata)
+	assert.Equal(t, expected.id, after.id)
+	assert.Equal(t, expected.commitHash, after.commitHash)
+	assert.Equal(t, len(expected.keys), len(after.keys))
+	for i, key := range expected.keys {
+		assert.Equal(t, key.public.Fingerprint[:], after.keys[i].public.Fingerprint[:])
+	}
 }

--- a/entities/identity/version_test.go
+++ b/entities/identity/version_test.go
@@ -20,20 +20,61 @@ type testVersionMockIdentity struct {
 	email string
 }
 
-func (m *testVersionMockIdentity) Name() string                                        { return m.name }
-func (m *testVersionMockIdentity) Login() string                                      { return m.login }
-func (m *testVersionMockIdentity) Email() string                                     { return m.email }
-func (m *testVersionMockIdentity) DisplayName() string                               { return m.name }
-func (m *testVersionMockIdentity) AvatarUrl() string                                 { return "" }
-func (m *testVersionMockIdentity) Keys() []*Key                                      { return nil }
-func (m *testVersionMockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) { return nil, nil }
-func (m *testVersionMockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key { return nil }
-func (m *testVersionMockIdentity) LastModification() timestamp.Timestamp             { return 0 }
-func (m *testVersionMockIdentity) LastModificationLamports() map[string]lamport.Time { return nil }
-func (m *testVersionMockIdentity) IsProtected() bool                                 { return false }
-func (m *testVersionMockIdentity) Validate() error                                   { return nil }
-func (m *testVersionMockIdentity) NeedCommit() bool                                  { return false }
-func (m *testVersionMockIdentity) Id() entity.Id                                     { return "" }
+func (m *testVersionMockIdentity) Name() string {
+	return m.name
+}
+
+func (m *testVersionMockIdentity) Login() string {
+	return m.login
+}
+
+func (m *testVersionMockIdentity) Email() string {
+	return m.email
+}
+
+func (m *testVersionMockIdentity) DisplayName() string {
+	return m.name
+}
+
+func (m *testVersionMockIdentity) AvatarUrl() string {
+	return ""
+}
+
+func (m *testVersionMockIdentity) Keys() []*Key {
+	return nil
+}
+
+func (m *testVersionMockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) {
+	return nil, nil
+}
+
+func (m *testVersionMockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key {
+	return nil
+}
+
+func (m *testVersionMockIdentity) LastModification() timestamp.Timestamp {
+	return 0
+}
+
+func (m *testVersionMockIdentity) LastModificationLamports() map[string]lamport.Time {
+	return nil
+}
+
+func (m *testVersionMockIdentity) IsProtected() bool {
+	return false
+}
+
+func (m *testVersionMockIdentity) Validate() error {
+	return nil
+}
+
+func (m *testVersionMockIdentity) NeedCommit() bool {
+	return false
+}
+
+func (m *testVersionMockIdentity) Id() entity.Id {
+	return ""
+}
 
 func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 	repo := repository.NewMockRepo()

--- a/entities/identity/version_test.go
+++ b/entities/identity/version_test.go
@@ -11,70 +11,9 @@ import (
 	"github.com/git-bug/git-bug/entity"
 	"github.com/git-bug/git-bug/repository"
 	"github.com/git-bug/git-bug/util/lamport"
-	"github.com/git-bug/git-bug/util/timestamp"
 )
 
-type testVersionMockIdentity struct {
-	name  string
-	login string
-	email string
-}
 
-func (m *testVersionMockIdentity) Name() string {
-	return m.name
-}
-
-func (m *testVersionMockIdentity) Login() string {
-	return m.login
-}
-
-func (m *testVersionMockIdentity) Email() string {
-	return m.email
-}
-
-func (m *testVersionMockIdentity) DisplayName() string {
-	return m.name
-}
-
-func (m *testVersionMockIdentity) AvatarUrl() string {
-	return ""
-}
-
-func (m *testVersionMockIdentity) Keys() []*Key {
-	return nil
-}
-
-func (m *testVersionMockIdentity) SigningKey(repo repository.RepoKeyring) (*Key, error) {
-	return nil, nil
-}
-
-func (m *testVersionMockIdentity) ValidKeysAtTime(clockName string, time lamport.Time) []*Key {
-	return nil
-}
-
-func (m *testVersionMockIdentity) LastModification() timestamp.Timestamp {
-	return 0
-}
-
-func (m *testVersionMockIdentity) LastModificationLamports() map[string]lamport.Time {
-	return nil
-}
-
-func (m *testVersionMockIdentity) IsProtected() bool {
-	return false
-}
-
-func (m *testVersionMockIdentity) Validate() error {
-	return nil
-}
-
-func (m *testVersionMockIdentity) NeedCommit() bool {
-	return false
-}
-
-func (m *testVersionMockIdentity) Id() entity.Id {
-	return ""
-}
 
 func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 	repo := repository.NewMockRepo()
@@ -95,7 +34,7 @@ func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 func TestVersionJSON(t *testing.T) {
 	repo := makeIdentityTestRepo(t)
 
-	testIdentity := &testVersionMockIdentity{name: "name", email: "email", login: "login"}
+	testIdentity := &mockIdentity{name: "name", email: "email", login: "login"}
 	keys := []*Key{
 		generatePublicKey(testIdentity),
 		generatePublicKey(testIdentity),

--- a/entities/identity/version_test.go
+++ b/entities/identity/version_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/git-bug/git-bug/util/lamport"
 )
 
-
-
 func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 	repo := repository.NewMockRepo()
 
@@ -34,7 +32,12 @@ func makeIdentityTestRepo(t *testing.T) repository.ClockedRepo {
 func TestVersionJSON(t *testing.T) {
 	repo := makeIdentityTestRepo(t)
 
-	testIdentity := &mockIdentity{name: "name", email: "email", login: "login"}
+	testIdentity := &mockIdentity{
+		name:  "name",
+		email: "email",
+		login: "login",
+	}
+
 	keys := []*Key{
 		generatePublicKey(testIdentity),
 		generatePublicKey(testIdentity),

--- a/entity/dag/operation_pack_test.go
+++ b/entity/dag/operation_pack_test.go
@@ -52,7 +52,7 @@ func TestOperationPackSignedReadWrite(t *testing.T) {
 		repo, author, _, resolver, def := maker()
 
 		err := author.(*identity.Identity).Mutate(repo, func(orig *identity.Mutator) {
-			orig.Keys = append(orig.Keys, identity.GenerateKey())
+			orig.Keys = append(orig.Keys, identity.GenerateKey(author))
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
This PR stores the full GPG private key to the `git-bug` keyring and marshals the full GPG public key into the `git-bug` `Identity` entity (user) that's committed to Git.  This change is non-breaking but foundational - it allows future features such as exporting the GPG public keys associated with one or all users and unifies `git-bug`'s commit signing and verification with Git itself.

Storing just the ASCII-armored `*packet.PrivateKey` makes it impossible to recover the associated public key as the identities, sub-keys and certifications are stripped.  Likewise, marshaling just the `*packet.PublicKey` into the `git-bug` identity results in a public key that can perform certain verification functions, but can't be imported into GPG and therefore would never be used by Git.

For example, the current `git-bug` release produces the following ASCII-armored public key:

```
-----BEGIN PGP PUBLIC KEY BLOCK-----

xsBNBIhuCQABCADoUWB84tn1aEqWung+Ork32bbS2C96K7YkoWETYmkxJPCmvUHY
Fm8cp4v10tmP0PIfjv5urOBKP9qYRPN7DSg0CTG946tpAw/PvC71QZvMJTjuZDYf
+xCccxkEIu2Q60VHNYDQZNMtkglxcSk1uD4HcfTCBFCfj/cEhGaR9okj0LirOdh3
t/JsAS17x7Wqkbk4yowj3ABHucLwqXxiEo0Ri6Y9Co++HJ6u172I9dY9Cq7ThmQH
x2kBIYdlEVDwdGLRpnpTFiDFudyH7RgxhzRkz96HjpJuGQqvB6mtFCkWGrvecDGi
RKkZP2YgoH4m+NvVkOt7ih2OcRQRBVUcMhpNABEBAAHNBG5hbWXCwLsEEwEIAG8F
gmmm0+MCCwcJEBstdUeOxeZ4NRQAAAAAABwAEHNhbHRAbm90YXRpb25zLm9wZW5w
Z3Bqcy5vcmfpLeuBJ4hudiUAPXgt/TKzAhUIAhYAAhkBApsDAh4BFiEEavUI3GLI
nMNJn2owGy11R47F5ngAACkNCAC79HI+xm73WjnXUMqXjunqHmUIxrF3GMGjkSF3
YKGj/qWWmRtFF2gzE7oeLiGnELwvopslM/9b6lpyNn1CLlDCRe1F8jEJKcK03aG9
/H0y29kwC+E98ooren1lB1HYpEG6Ad+AuEdZQL0jv1telJ+a7sL3x5Zr0QnLSy4x
isD16V1YXW+c9QPb4hDzBnM/XdtaBJr8cN/ZByijCBXacJcpbIAqy6SKscN5z1BI
Y8DaCABw+iEvatbB0FYBeahPLxWo3Wu5mAVRpN4H6bbSJr80vdoA2GhXMbW/7d/V
SEo74zrBklzdeU6CqpHpW/I8pUp374qJ6X6uMXNkuX4Uj7M7
=IjN0
-----END PGP PUBLIC KEY BLOCK-----
```

This key cannot be imported into GPG due to the missing identity and self-signed certification (and because the creation time is set to the Go zero value of `time.Time`):

```
$ gpg --import bug-pub.asc 
gpg: public key 1B2D75478EC5E678 is 5976 days newer than the signature
gpg: public key 1B2D75478EC5E678 is 5976 days newer than the signature
gpg: key 1B2D75478EC5E678: new key but contains no user ID - skipped
gpg: Total number processed: 1
gpg:           w/o user IDs: 1
```

Therefore, `git` can't verify the signature produced when the associated user commits a new bug:

```
$ git log --all --show-signature
commit 614c8d7cfbd62c7499b626da45719f30ae46aea6
gpg: Signature made Tue 03 Mar 2026 07:28:19 AM EST
gpg:                using RSA key 6AF508DC62C89CC3499F6A301B2D75478EC5E678
gpg: Can't check signature: No public key
Author:  <>
Date:   Tue Mar 3 07:28:19 2026 -0500
```

The updated code produces an ASCII-armored public key that includes the identities, sub-keys and certifications.  This key is therefore noticeably larger:

```
-----BEGIN PGP PUBLIC KEY BLOCK-----

xsBNBGmm164BCAClhH7EdPWiFdRkOFRzAFlH5TnzYybjjSwllzWX1Y74ehgQ6rUx
OvgZgDa+sIDXkOZvX97RfMMTNRNxMFcShyt0/bRFOG6D77PwhzTOggYo6Iimr7W+
izKIPU8+5ExcaDHqpjMxoZMMjps2geWYDFyQFOk4YpA5ccw4G1MGUKH01sqw0CL3
H5tDXBxnhsvahUcmHIWTdWbcmejjerUlCSrwwN3++1vRT0trUj7NpYTYnCecyHBR
74BV2GNTEccivEFreNOQoyxQTOLCTS52iSFLr62nD8Cipc+Om5MlCRpy+eQS9Vf2
PYOqCXQ5HbVGhpRUISC8OCj9kXGOH8/WVOGtABEBAAHNKlN0ZXZlIE1veWVyIChz
bW95ZXIxKSA8c21veWVyMUBzZWxlc3kuY29tPsLAuwQTAQgAbwWCaabXrgILBwkQ
DXvtO+7HRzQ1FAAAAAAAHAAQc2FsdEBub3RhdGlvbnMub3BlbnBncGpzLm9yZ3Zq
0mvwhUBxsIoS7OLbnxkCFQgCFgACGQECmwMCHgEWIQR5c2BG2hYU+u6JJ6gNe+07
7sdHNAAAwaAH/0S1jGTxQVC4iumsl7GB8XnvEDeGSJrUut6VDqMsoQOBHHte9P8D
U4AGo7SdiVUzQQ09fbHfSS19aW+Vd5YKZ8cyrWY578GKdmxV+awIwit1du46qfTr
1l8djhvURwGn+clWf43wlGOUM9qOJwSpvL5qxdS6XZAfukIlA0O29IdmLY0YOn+a
akGPkBOeHC7vG63TAfYKKp1/XY2KxGHvZ/aKH8sg/pp5mzzwyfuLNkgPURoYmv0Y
h7r5/LR3r7VgkGJjTLtCok0qzHELmwFw5gxYHSDVHrip/c7iSl9HywQ2W/fjWpR6
unah3szDaGbghTdO/RmJYnrHyS+aBCLSfl7OwE0EaabXrgEIAMVkAIkPgADgE/sN
mNowxc4bSxCSTSYxhthfVZ5T+3QXOz1WSQQdhLQlmSRP5zll+VWgm6jT4f7HKWMK
pY77GVbqWmRLq8Im56X3zwaZ23PTSaSAO8LPB060xxgpU87QHvO3Lmzxcc/CHkCb
9/rh7uQT+XlK75JlPOMexdCerMG6w6CXqcR6Jy+Ek2hnZcB0beK3mV9tz4JGOxKZ
yrCKkK99unmMOxSB+ul72gq98KHSxwXHXLvL4zdAMB40Ulm2m+e4fvedeFCzDeeP
QRQwfGZStCoimss+XIsM82txDc/XMlzs2Y5LaEobe1XpgPIneCag6YkbXPK+Clgw
25xe+ssAEQEAAcLArAQYAQgAYAWCaabXrgkQDXvtO+7HRzQ1FAAAAAAAHAAQc2Fs
dEBub3RhdGlvbnMub3BlbnBncGpzLm9yZwZFE8eSSldaU8NMM/qUoPACmwwWIQR5
c2BG2hYU+u6JJ6gNe+077sdHNAAAbfAH/Rte7alumoQZlpOJ41gq9ptII9qD51u9
omq8qV9+EaO4qzPsj/NJQheROROBjGDspgpHL15RUAxE3ZgtzuBe8JDekPjyLsIG
5GK7CiIX9jEz8kHOERKe69ZGqEVOKzb6BRPZgfjL9eLoNHemJvRQYiJWdpjdj+pF
x6nZmmOalDNlna28ofdTv6VtUjkiSDL1GGCBL802xNncQFx7JfnyE0kYa9ZZsHq9
RufTN1Ah5hhKYSTaBiXzTC3BXpJjfpdzIhfIt7CGez/73gaPryKA/YBD5X+ExPRn
bCkZ8CWsEqA2etjvsPq+ydt8yEJmmeLy6FiVps+e3eXoxU1UDqbvRHU=
=MblH
-----END PGP PUBLIC KEY BLOCK-----
```

But more importantly, this key can be imported into GPG:

```
$ gpg --import bug-pub.asc 
gpg: key 0D7BED3BEEC74734: public key "Steve Moyer (smoyer1) <smoyer1@selesy.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```

The `git-bug` commit is now recognized as having a valid signature:

```
$ git log --all --show-signature
commit bb499be38807b2172008d3c5c7be27cb87f95004
gpg: Signature made Tue 03 Mar 2026 07:44:30 AM EST
gpg:                using RSA key 79736046DA1614FAEE8927A80D7BED3BEEC74734
gpg: checking the trustdb
gpg: marginals needed: 3  completes needed: 1  trust model: pgp
gpg: depth: 0  valid:   6  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 6u
gpg: Good signature from "Steve Moyer (smoyer1) <smoyer1@selesy.com>" [ultimate]
Primary key fingerprint: 7973 6046 DA16 14FA EE89  27A8 0D7B ED3B EEC7 4734
Author:  <>
Date:   Tue Mar 3 07:44:30 2026 -0500
```

Note that the presence or absence of signatures on `git-bug` commits doesn't impact the behavior of "Require sIgned commits" on GitHub branch rules:

<img width="957" height="98" alt="image" src="https://github.com/user-attachments/assets/6e8bde9e-d180-41fe-9191-285a0228293f" />
