### PR TITLE
test: use work_items url for gitlab issues

### DIFF
--- a/bridge/gitlab/import_test.go
+++ b/bridge/gitlab/import_test.go
@@ -49,7 +49,7 @@ func TestGitlabImport(t *testing.T) {
 	}{
 		{
 			name: "simple issue",
-			url:  "https://gitlab.com/git-bug/test/-/issues/1",
+			url:  "https://gitlab.com/git-bug/test/-/work_items/1",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "simple issue", "initial comment", nil),
@@ -60,7 +60,7 @@ func TestGitlabImport(t *testing.T) {
 		},
 		{
 			name: "empty issue",
-			url:  "https://gitlab.com/git-bug/test/-/issues/2",
+			url:  "https://gitlab.com/git-bug/test/-/work_items/2",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "empty issue", "", nil),
@@ -69,7 +69,7 @@ func TestGitlabImport(t *testing.T) {
 		},
 		{
 			name: "complex issue",
-			url:  "https://gitlab.com/git-bug/test/-/issues/3",
+			url:  "https://gitlab.com/git-bug/test/-/work_items/3",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "complex issue", "initial comment", nil),
@@ -86,7 +86,7 @@ func TestGitlabImport(t *testing.T) {
 		},
 		{
 			name: "editions",
-			url:  "https://gitlab.com/git-bug/test/-/issues/4",
+			url:  "https://gitlab.com/git-bug/test/-/work_items/4",
 			bug: &bug.Snapshot{
 				Operations: []dag.Operation{
 					bug.NewCreateOp(author, 0, "editions", "initial comment edited", nil),


### PR DESCRIPTION
Gitlab has made a breaking change in that issues are returned from their
API with the new `work_items` URL schema.

That is, what used to be:

    https://gitlab.com/:group/:project/-/issues/:id

is now:

    https://gitlab.com/:group/:project/-/work_items/:id

This caused TestGitlabImport to fail, because we are using the hardcoded
URL in the test structures to match against issues fetched from the API.

Change-Id: I2aad98118fe4da7c56bdf2a83412ea753e1bbd23