### PR TITLE
ci: remove redundant workflow: mirror

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -46,34 +46,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           auto-push: true
-
-  mirror:
-    if: github.repository == 'git-bug/git-bug' && github.run_attempt == '1'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      # we use a custom deploy key in order to allow the workflow to bypass
-      # branch protection rules. without this, pushing will be rejected
-      - name: setup authentication
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh-agent.sock
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.TRUNK_MIRROR_KEY }}" > ~/.ssh/id_rsa
-          chmod 0600 ~/.ssh/id_rsa
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add ~/.ssh/id_rsa
-
-      - name: push to refs/heads/master
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh-agent.sock
-        run: |-
-          git config user.name git-bug-bot
-          git config user.email no-reply@git-bug.org
-          git remote set-url origin git@github.com:git-bug/git-bug.git
-          git push --atomic origin HEAD:refs/heads/master


### PR DESCRIPTION
This workflow existed to mirror commits from `trunk` to the old default
branch. Official support for maintaining the old default branch ended on
January 31 2026, and as such, it no longer serves a purpose.

Refs: #1404
Change-Id: Idd053c299c96958ffb85c3620cdef7ef29a59126